### PR TITLE
Get all callregistry types

### DIFF
--- a/tomatic/api.py
+++ b/tomatic/api.py
@@ -468,10 +468,10 @@ async def updateCallLog(user, request: Request):
 
 @app.get('/api/updateClaims')
 def updateClaimTypes():
-    message = 'ok'
     with erp() as O:
         CallRegistry().importClaimTypes(O)
     return yamlfy(info=ns(message='ok'))
+
 
 @app.get('/api/getClaims')
 def getClaimTypes():
@@ -509,6 +509,13 @@ async def postAtrCase(request: Request):
     return yamlfy(info=ns(
         message="ok"
     ))
+
+
+@app.get('/api/updateCrmCategories')
+def updateCrmCategories():
+    with erp() as O:
+        CallRegistry().importCrmCategories(O)
+    return yamlfy(info=ns(message='ok'))
 
 
 @app.get('/api/getInfos')

--- a/tomatic/callregistry.py
+++ b/tomatic/callregistry.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from yamlns import namespace as ns
 from consolemsg import error, step, warn, u
 from .claims import Claims
+from .kalinfo.crmcase import CrmCase
 
 def fillConfigurationInfo():
     return ns.load('config.yaml')
@@ -86,6 +87,15 @@ class CallRegistry(object):
 
         Path(CONFIG.claims_file).write_text(
             '\n'.join([u(x) for x in erp_claims]),
+            encoding='utf8',
+        )
+
+    def importCrmCategories(self, erp):
+        categories = CrmCase(erp)
+        erp_crm_categories = categories.get_crm_categories()
+
+        Path(CONFIG.info_cases).write_text(
+            '\n'.join([u(x) for x in erp_crm_categories]),
             encoding='utf8',
         )
 

--- a/tomatic/kalinfo/crmcase.py
+++ b/tomatic/kalinfo/crmcase.py
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+
+class CrmCase(object):
+
+    def __init__(self, erp):
+        self.erp = erp
+
+    def get_crm_categories(self):
+        crm_categories_model = self.erp.model('crm.case.categ')
+        all_crm_categories = crm_categories_model.search([])
+
+        crm_categories = []
+        for category_id in all_crm_categories:
+            category = crm_categories_model.read(
+                category_id, ['name']
+            )
+            categ_name = category.get('name')
+            if categ_name.startswith('['):
+                crm_categories.append(categ_name)
+
+        return crm_categories
+
+
+# vim: et ts=4 sw=4

--- a/tomatic/kalinfo/crmcase_test.py
+++ b/tomatic/kalinfo/crmcase_test.py
@@ -1,0 +1,48 @@
+# -*- encoding: utf-8 -*-
+
+import unittest
+import os
+from unittest.case import skip
+from erppeek_wst import ClientWST
+from xmlrpc import client as xmlrpclib
+from yamlns import namespace as ns
+from .crmcase import CrmCase
+
+try:
+    import dbconfig
+except ImportError:
+    dbconfig = None
+
+@unittest.skipIf(os.environ.get("TRAVIS"),
+    "Database not available in Travis")
+@unittest.skipIf(
+    not dbconfig or not dbconfig.erppeek,
+    "Requires configuring dbconfig.erppeek"
+)
+class Claims_Test(unittest.TestCase):
+
+    def setUp(self):
+        if not dbconfig:
+            return
+        if not dbconfig.erppeek:
+            return
+        self.erp = ClientWST(**dbconfig.erppeek)
+        self.erp.begin()
+
+    def tearDown(self):
+        try:
+            self.erp.rollback()
+            self.erp.close()
+        except xmlrpclib.Fault as e:
+            if 'transaction block' not in e.faultCode:
+                raise
+
+    @skip("there are nocategories in testing")
+    def test_getCrmCategories(self):
+        crm_case = CrmCase(self.erp)
+        crm_categories = crm_case.get_crm_categories()
+        categories = ns.load('b2bdata/categories_b2b.yaml')
+        self.assertEqual(crm_categories, categories)
+
+
+# vim: et ts=4 sw=4

--- a/tomatic/static/components/callinfo.js
+++ b/tomatic/static/components/callinfo.js
@@ -19,6 +19,7 @@ CallInfo.currentPerson = 0; // Selected person from search data
 CallInfo.currentContract = 0; // Selected contract selected person
 CallInfo.callLog = []; // User call registry
 CallInfo.updatingClaims = false; // Whether we are still loading claim types
+CallInfo.updatingCrmCategories = false; // Whether we are still loading crm categoies
 CallInfo.autoRefresh = true; // whether we are auto searching on incomming calls
 CallInfo.call = {
     'phone': "", // phone of the currently selected call registry
@@ -35,6 +36,7 @@ CallInfo.call_reasons = {
 CallInfo.extras_dict = {};
 CallInfo.savingAnnotation = false;
 
+
 CallInfo.clear = function() {
   CallInfo.call.phone = "";
   CallInfo.call.log_call_reasons = [];
@@ -48,6 +50,7 @@ CallInfo.clear = function() {
   CallInfo.file_info = {};
 }
 
+
 CallInfo.changeUser = function(newUser) {
   CallInfo.search = "";
   CallInfo.clear();
@@ -58,10 +61,12 @@ CallInfo.changeUser = function(newUser) {
   CallInfo.autoRefresh = true;
 }
 
+
 CallInfo.callReceived = function(date, phone) {
   if (!CallInfo.autoRefresh) { return; }
   CallInfo.callSelected(date,phone)
 }
+
 
 CallInfo.callSelected = function(date, phone) {
   CallInfo.clear();
@@ -74,13 +79,13 @@ CallInfo.callSelected = function(date, phone) {
 }
 
 
-
 function formatContractNumber(number) {
   // some contract numbers get converted  to int and lose their padding
   var result = number+"";
   while (result.length < 7) result = "0" + result;
   return result;
 }
+
 
 function contractNumbers(info) {
   var result = {}
@@ -93,11 +98,13 @@ function contractNumbers(info) {
   return Object.keys(result);
 }
 
+
 CallInfo.getExtras = function (extras) {
   return extras.map(function(extra) {
     return CallInfo.extras_dict[extra];
   });
 }
+
 
 CallInfo.selectedPartner = function() {
   if (!CallInfo.file_info) { return null; }
@@ -108,6 +115,7 @@ CallInfo.selectedPartner = function() {
   return partner;
 };
 
+
 CallInfo.selectedContract = function() {
   var partner = CallInfo.selectedPartner();
   if (partner === null) { return null; }
@@ -116,9 +124,11 @@ CallInfo.selectedContract = function() {
   return partner.contracts[CallInfo.currentContract];
 };
 
+
 CallInfo.selectContract = function(idx) {
   CallInfo.currentContract = idx;
 };
+
 
 var retrieveInfo = function () {
   m.request({
@@ -166,6 +176,7 @@ var retrieveInfo = function () {
   });
 };
 
+
 CallInfo.getClaims = function() {
   m.request({
       method: 'GET',
@@ -176,7 +187,7 @@ CallInfo.getClaims = function() {
       if (response.info.message !== "ok" ) {
           console.debug("Error al obtenir les reclamacions: ", response.info.message)
       }
-      else{
+      else {
         CallInfo.call_reasons.general = response.info.claims;
         CallInfo.extras_dict = response.info.dict;
         CallInfo.call_reasons.extras = Object.keys(response.info.dict);
@@ -186,6 +197,27 @@ CallInfo.getClaims = function() {
   });
 };
 CallInfo.getClaims();
+
+
+CallInfo.getInfos = function() {
+  m.request({
+      method: 'GET',
+      url: '/api/getInfos',
+      extract: deyamlize,
+  }).then(function(response){
+      console.debug("Info GET Response: ",response);
+      if (response.info.message !== "ok" ) {
+          console.debug("Error al obtenir els infos: ", response.info.message)
+      }
+      else {
+        CallInfo.call_reasons.infos = response.info.infos;
+      }
+  }, function(error) {
+      console.debug('Info GET apicall failed: ', error);
+  });
+};
+CallInfo.getInfos();
+
 
 CallInfo.updateClaims = function() {
   CallInfo.updatingClaims = true;
@@ -207,6 +239,25 @@ CallInfo.updateClaims = function() {
   });
 };
 
+CallInfo.updateCrmCategories = function() {
+  CallInfo.updatingCrmCategories = true;
+  m.request({
+    method: 'GET',
+    url: '/api/updateCrmCategories',
+    extract: deyamlize,
+  }).then(function(response){
+    console.debug("Info GET Response: ",response);
+    if (response.info.message !== "ok" ) {
+      console.debug("Error al actualitzar les categories de trucades telefòniques: ", response.info.message)
+    }
+    else{
+      CallInfo.updatingCrmCategories = false;
+      CallInfo.getInfos();
+    }
+  }, function(error) {
+    console.debug('Info GET apicall failed: ', error);
+  });
+};
 
 CallInfo.getLogPerson = function () {
   CallInfo.callLog = []

--- a/tomatic/static/components/callinfopage.js
+++ b/tomatic/static/components/callinfopage.js
@@ -88,7 +88,23 @@ CallInfoPage.settingsDialog = function() {
       CallInfo.updatingClaims ? [
         m("b", "Actualitzant reclamacions"),
         m("div", "Pot portar el seu temps, pots sortir mentrestant.")
-      ] : m("b", "Actualitzar llistat de reclamacions")
+      ] : m("b", "Actualitzar llistat de reclamacions"),
+      m("p"),
+      m(Button, {
+        className: 'btn-refresh',
+        label: refreshIcon(),
+        border: 'true',
+        disabled: CallInfo.updatingCrmCategories,
+        events: {
+          onclick: function() {
+            CallInfo.updateCrmCategories();
+          },
+        },
+      }, m(Ripple)),
+      CallInfo.updatingCrmCategories ? [
+        m("b", "Actualitzar categories (Trucades Telefòniques)"),
+        m("div", "Pot portar el seu temps, pots sortir mentrestant.")
+      ] : m("b", "Actualitzar categories (Trucades Telefòniques)")
     ],
     footerButtons: m(Button, {
       label: "Sortir",

--- a/tomatic/static/components/questionnaire.js
+++ b/tomatic/static/components/questionnaire.js
@@ -23,26 +23,6 @@ var call_reasons = CallInfo.call_reasons;
 var reason_filter = "";
 
 
-var getInfos = function() {
-  m.request({
-      method: 'GET',
-      url: '/api/getInfos',
-      extract: deyamlize,
-  }).then(function(response){
-      console.debug("Info GET Response: ",response);
-      if (response.info.message !== "ok" ) {
-          console.debug("Error al obtenir els infos: ", response.info.message)
-      }
-      else{
-        call_reasons.infos = response.info.infos;
-      }
-  }, function(error) {
-      console.debug('Info GET apicall failed: ', error);
-  });
-};
-getInfos();
-
-
 var postClaim = function(claim) {
   m.request({
     method: 'POST',


### PR DESCRIPTION
### Case
We want to update CRM categories (before called Info types) using a button in Kalinfo interface.

### Solution
A button was added with the refresh claims button, and a CrmCase model was added to manage that cases.

Added endpoint `/api/updateCrmCategories`. That returns:
```
ns(
    info = ns(
        message='ok'
    )
)
```
If everything is ok.

### TODO:
- [ ] Tests (there is a test `test_getCrmCategories`, but it's skipped because there are not CRM categories in testing) 
- [ ] Documentation