### PR TITLE
Self Consumption Alert

### DIFF
--- a/tomatic/callinfo.py
+++ b/tomatic/callinfo.py
@@ -356,6 +356,7 @@ class CallInfo(object):
             'no_estimable',
             'comptadors',
             'debt_amount',
+            'autoconsumo',
         ])
         all_contracts_dict = {c['id']: c for c in all_contracts if c}
         for contract_id in contracts_ids:
@@ -431,6 +432,9 @@ class CallInfo(object):
                     invoices=last_invoices,
                     has_debt=debt if debt > 0.0 else False,
                     atr_cases=atr_cases,
+                    selfconsumption=contract['autoconsumo'] not in [
+                        '00',
+                    ],
                 )
             )
         return ret

--- a/tomatic/static/components/callinfo_style.styl
+++ b/tomatic/static/components/callinfo_style.styl
@@ -184,6 +184,11 @@ body
           font-weight: bold
           margin-right: 5px
           color: green
+        .label-selfconsumption
+          display: inline-block
+          font-weight: bold
+          margin-right: 5px
+          color: #366
         .label-generation
           display: inline-block
           font-weight: bold

--- a/tomatic/static/components/contract.js
+++ b/tomatic/static/components/contract.js
@@ -284,19 +284,19 @@ var lastInvoices = function(invoices) {
 }
 
 var extraInfo = function(contract) {
-  var autoconsum = contract.autoconsum;
+  var selfconsumption = contract.selfconsumption;
   var generation = contract.generation;
   var energetica = contract.energetica;
   var suspended_invoicing = contract.suspended_invoicing;
   var has_debt = contract.has_debt;
 
-  if (!autoconsum && !generation && !energetica && !suspended_invoicing && !has_debt) {
+  if (!selfconsumption && !generation && !energetica && !suspended_invoicing && !has_debt) {
     info = m("no-info", "No hi ha informació extra.")
   }
   else {
     info = m(".extra-info", [
       m("",
-        autoconsum ? m(".label-autoconsum","Autoconsum.") : ""
+        selfconsumption ? m(".label-selfconsumption","Autoconsum.") : ""
       ),
       m("",
         generation ? m(".label-generation","Rep Generation.") : ""

--- a/tomatic/static/components/contract.js
+++ b/tomatic/static/components/contract.js
@@ -101,10 +101,7 @@ var contractFields = function(contract, partner) {
       (contract.pending_state != "" ? contract.pending_state : "Esborrany")
     ),
     m("br"),
-    extraInfo(
-      contract.generation, contract.energetica,
-      contract.suspended_invoicing, contract.has_debt
-    ),
+    extraInfo(contract),
   ]);
 }
 
@@ -286,14 +283,21 @@ var lastInvoices = function(invoices) {
   );
 }
 
-var extraInfo = function(
-  generation, energetica, suspended_invoicing, has_debt
-) {
-  if (!generation && !energetica && !suspended_invoicing && !has_debt) {
+var extraInfo = function(contract) {
+  var autoconsum = contract.autoconsum;
+  var generation = contract.generation;
+  var energetica = contract.energetica;
+  var suspended_invoicing = contract.suspended_invoicing;
+  var has_debt = contract.has_debt;
+
+  if (!autoconsum && !generation && !energetica && !suspended_invoicing && !has_debt) {
     info = m("no-info", "No hi ha informació extra.")
   }
   else {
     info = m(".extra-info", [
+      m("",
+        autoconsum ? m(".label-autoconsum","Autoconsum.") : ""
+      ),
       m("",
         generation ? m(".label-generation","Rep Generation.") : ""
       ),


### PR DESCRIPTION
WIP branch on adding a self-consumption alert to the contract in callinfo.

Because the alerts could be a lot more, and may change in the future, keeping them as positional parameters of a function can be a maintenance madness. The first step has been refactoring this and adding a safe check for a non-existing-yet selfconsumption attribute.

TODO

- In Callinfo, obtain the attribute from the erp contract and map it to a proper message using the information Fran gave us.