### PR TITLE
force get_leaves calls without hour

### DIFF
--- a/tomatic/busy_test.py
+++ b/tomatic/busy_test.py
@@ -88,7 +88,9 @@ class BusyTest(unittest.TestCase):
 
 	def test_onWeek_oneOnMonday(self):
 		sequence = busy.onWeek(isodate('2018-01-01'), [
-			self.tupleToNs('F', 'maria', isodate('2018-01-01'), '1101', u'reunió POL'),
+			    self.tupleToNs(
+                    'F', 'maria', isodate('2018-01-01'), '1101', u'reunió POL'
+                ),
 			])
 		self.assertBusyListEqual(list(sequence), [
 			('F', 'maria', u'dl', '1101', u'reuni\xf3 POL'),

--- a/tomatic/retriever.py
+++ b/tomatic/retriever.py
@@ -126,7 +126,9 @@ def downloadVacations_odoo(config):
     erp = erppeek.Client(**dbconfig.tomatic.holidaysodoo)
     firstDay = addDays(config.monday, 0)
     lastDay = addDays(config.monday, 4)
-    absences = erp.model('hr.leave').get_leaves(str(firstDay), str(lastDay))
+    absences = erp.model('hr.leave').get_leaves(
+        firstDay.strftime("%Y-%m-%d"), lastDay.strftime("%Y-%m-%d")
+    )
 
     def dateFromIso(isoString):
         return datetime.datetime.strptime(


### PR DESCRIPTION
## Previous behaviour

The string casting of `datetime.date` returns a `%Y-%m%d %H:%M:%s` string with 0's in hours, minutes and seconds.

If we call `erp.model('hr.leave').get_leaves` with `start_time="2022-10-28T00:00:00"` don't return the first day of vacation because this starts at `07:00:00`.

## Current behaviour

Calls `erp.model('hr.leave').get_leaves` with `%Y-%m%d` format and return the first day of vacation