### PR TITLE
New ningu limit edit time table

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -45,6 +45,7 @@ maxNodesToPersevere: 10000
 costLimit: 200
 descartaNoPrometedores: true
 deixaEsmorzar: true
+maxNingusPerTurn: 2
 noVolenEsmorzar:
 - david
 - ningu

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         'lxml',
         'erppeek',
         'ERPPeek-WST',
+        'mock',
     ],
     classifiers = [
         'Programming Language :: Python',

--- a/tomatic/api.py
+++ b/tomatic/api.py
@@ -213,7 +213,7 @@ async def editSlot(week, day, houri: int, turni: int, name, request: Request):
     graella = schedules.load(week)
     # TODO: Ensure day, houri, turni and name are in graella
     oldName = graella.timetable[day][int(houri)][int(turni)]
-    if name == 'ningu' and occurrencesInTurn(graella, day, houri, name) == 2:  # TODO: Magic number
+    if name == 'ningu' and occurrencesInTurn(graella, day, houri, name) == CONFIG.maxNingusPerTurn:
         raise ApiError("Hi ha masses Ningu en aquest torn")
     graella.timetable[day][int(houri)][int(turni)] = name
     graella.overload = graella.get('overload', ns())

--- a/tomatic/api.py
+++ b/tomatic/api.py
@@ -78,6 +78,11 @@ app = FastAPI()
 app.include_router(Planner, prefix='/api/planner')
 
 
+def occurrencesInTurn(graella, day, houri, name):
+    nominated = graella.timetable[day][int(houri)]
+    return nominated.count(name)
+
+
 class ApiError(Exception): pass
 
 def yamlfy(status=200, data=[], **kwd):
@@ -208,6 +213,8 @@ async def editSlot(week, day, houri: int, turni: int, name, request: Request):
     graella = schedules.load(week)
     # TODO: Ensure day, houri, turni and name are in graella
     oldName = graella.timetable[day][int(houri)][int(turni)]
+    if name == 'ningu' and occurrencesInTurn(graella, day, houri, name) == 2:  # TODO: Magic number
+        raise ApiError("Hi ha masses Ningu en aquest torn")
     graella.timetable[day][int(houri)][int(turni)] = name
     graella.overload = graella.get('overload', ns())
     graella.overload[oldName] = graella.overload.get(oldName, 0) -1

--- a/tomatic/api_test.py
+++ b/tomatic/api_test.py
@@ -21,20 +21,23 @@ class Api_Test(unittest.TestCase):
         self.maxDiff = None
         self.client = TestClient(api.app)
 
+    def getTimeTableObjectStructure(self, time_table):
+        return ns(
+            hours=['09:00', '10:15'],
+            turns=['L1', 'L2'],
+            timetable=ns(time_table)
+        )
+
     @patch("tomatic.api.schedulestorage.Storage.load")
     @patch("tomatic.api.schedulestorage.Storage.save")
     def test_editSlot_baseCase(self, mocked_saver, mocked_loader):
         # Given a time table
-        old_time_table = ns(
-            hours=['09:00', '10:15'],
-            turns=['L1', 'L2'],
-            timetable=ns(
-                dl=[
-                    ['vic', 'cire', 'carme'],
-                    ['vic', 'cire', 'carme'],
-                ]
-            )
-        )
+        old_time_table = self.getTimeTableObjectStructure({
+            'dl': [
+                ['vic', 'cire', 'carme'],
+                ['vic', 'cire', 'carme'],
+            ]
+        })
         mocked_loader.return_value = old_time_table
         day = 'dl'
         hour_index = 0
@@ -60,16 +63,12 @@ class Api_Test(unittest.TestCase):
     @patch("tomatic.api.schedulestorage.Storage.save")
     def test_editSlot_ningusLimit(self, mocked_saver, mocked_loader):
         # Given a time table
-        old_time_table = ns(
-            hours=['09:00', '10:15'],
-            turns=['L1', 'L2'],
-            timetable=ns(
-                dl=[
-                    ['vic', 'ningu', 'ningu'],
-                    ['vic', 'ningu', 'ningu'],
-                ]
-            )
-        )
+        old_time_table = self.getTimeTableObjectStructure({
+            'dl': [
+                ['vic', 'ningu', 'ningu'],
+                ['vic', 'ningu', 'ningu'],
+            ]
+        })
         mocked_loader.return_value = old_time_table
         day = 'dl'
         hour_index = 0

--- a/tomatic/api_test.py
+++ b/tomatic/api_test.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 import copy
+import yaml
 import unittest
 from datetime import datetime
 from mock import patch
 
+from yaml.loader import SafeLoader
 from yamlns import namespace as ns
 from . import api
 from fastapi.testclient import TestClient
@@ -53,6 +55,46 @@ class Api_Test(unittest.TestCase):
         new_time_table = copy.deepcopy(old_time_table)
         new_time_table.timetable[day][hour_index][turn_index] = name
         mocked_saver.assert_called_with(new_time_table)
+
+    @patch("tomatic.api.schedulestorage.Storage.load")
+    @patch("tomatic.api.schedulestorage.Storage.save")
+    def test_editSlot_ningusLimit(self, mocked_saver, mocked_loader):
+        # Given a time table
+        old_time_table = ns(
+            hours=['09:00', '10:15'],
+            turns=['L1', 'L2'],
+            timetable=ns(
+                dl=[
+                    ['vic', 'ningu', 'ningu'],
+                    ['vic', 'ningu', 'ningu'],
+                ]
+            )
+        )
+        mocked_loader.return_value = old_time_table
+        day = 'dl'
+        hour_index = 0
+        turn_index = 0
+        name = 'ningu'
+
+        # When we change one person in time table
+        response = self.client.patch(
+            '/api/graella/2022-10-31/{}/{}/{}/{}'.format(
+                day, hour_index, turn_index, name
+            ),
+            json="vic"
+        )
+
+        # API returns 400 error
+        self.assertEquals(response.status_code, 400)
+        # with a message of the error that occurred
+        yaml_response = response.text
+        content_response = yaml.load(yaml_response, Loader=SafeLoader)
+        self.assertEquals(
+            content_response,
+            {'error': 'Hi ha masses Ningu en aquest torn'}
+        )
+        # and time table wasn't saved
+        mocked_saver.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tomatic/api_test.py
+++ b/tomatic/api_test.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 
-import b2btest
+import copy
 import unittest
 from datetime import datetime
+from mock import patch
 
+from yamlns import namespace as ns
 from . import api
+from fastapi.testclient import TestClient
+
 
 def setNow(year,month,day,hour,minute):
     api.now=lambda:datetime(year,month,day,hour,minute)
@@ -12,10 +16,44 @@ def setNow(year,month,day,hour,minute):
 class Api_Test(unittest.TestCase):
 
     def setUp(self):
-        api.app.config['TESTING'] = True
-        self.app = api.app.test_client()
         self.maxDiff = None
-        self.b2bdatapath = "testdata"
+        self.client = TestClient(api.app)
+
+    @patch("tomatic.api.schedulestorage.Storage.load")
+    @patch("tomatic.api.schedulestorage.Storage.save")
+    def test_editSlot_baseCase(self, mocked_saver, mocked_loader):
+        # Given a time table
+        old_time_table = ns(
+            hours=['09:00', '10:15'],
+            turns=['L1', 'L2'],
+            timetable=ns(
+                dl=[
+                    ['vic', 'cire', 'carme'],
+                    ['vic', 'cire', 'carme'],
+                ]
+            )
+        )
+        mocked_loader.return_value = old_time_table
+        day = 'dl'
+        hour_index = 0
+        turn_index = 0
+        name = 'cire'
+
+        # When we change one person in time table
+        response = self.client.patch(
+            '/api/graella/2022-10-31/{}/{}/{}/{}'.format(
+                day, hour_index, turn_index, name
+            ),
+            json="vic"
+        )
+
+        # The request was success
+        self.assertEquals(response.status_code, 200)
+        # and API saves the time table with change applied
+        new_time_table = copy.deepcopy(old_time_table)
+        new_time_table.timetable[day][hour_index][turn_index] = name
+        mocked_saver.assert_called_with(new_time_table)
+
 
 if __name__ == "__main__":
 

--- a/tomatic/ui/components/tomatic.js
+++ b/tomatic/ui/components/tomatic.js
@@ -183,7 +183,7 @@ Tomatic.editCell = function(day,houri,turni,name,myname) {
 		Tomatic.requestGrid(Tomatic.grid().week);
 	}, function(error) {
 		Tomatic.error("Problemes editant la graella: "+
-			(error.error || "Inexperat"));
+			(error || "Inexperat"));
 	});
 };
 Tomatic.setPersonData = function (name, data) {


### PR DESCRIPTION
## Previous behaviour

Can edit time table without limitations

## Current behaviour

In a turn can only be `maxNingusPerTurn` of ningus