### PR TITLE
✨ Change idealLoad by fullLoad which consider holidays and free days

### DIFF
--- a/tomatic/minizinc.py
+++ b/tomatic/minizinc.py
@@ -24,24 +24,24 @@ class Menu:
 
     def __init__(self, config):
         laborable_days = laborableWeekDays(config.monday)
-        self.nPersones = len(config.idealLoad)
+        self.nPersones = len(config.fullLoad)
         self.nLinies = config.nTelefons
         self.nSlots = len(config.hours) - 1
         self.nNingus = config.nNingusMinizinc
         self.nDies = len(laborable_days)
         self.maxTorns = config.maximHoresDiariesGeneral
-        self._saveNamesAndTurns(config.idealLoad)
+        self._saveNamesAndTurns(config.fullLoad)
         self.laborable_days = laborable_days
         self.WEEKDAY = { day: i for i, day in enumerate(laborable_days) }
         self.indisponibilitats = self._indisponibilities(config)
         self.preferencies = self._preferences()
 
-    def _saveNamesAndTurns(self, ideals):
-        persons = list(ideals.keys())
+    def _saveNamesAndTurns(self, fulls):
+        persons = list(fulls.keys())
         random.shuffle(persons)
-        shuffled_ideals = [(key, ideals[key]) for key in persons]
-        names, turns = zip(*shuffled_ideals)
-        self.nTorns = list(turns)
+        shuffled_fulls = [(key, fulls[key]) for key in persons]
+        names, turns = zip(*shuffled_fulls)
+        self.nTorns  = list(turns)
         self.names = list(names)
 
     def _indisponibilities(self, config):

--- a/tomatic/minizinc_test.py
+++ b/tomatic/minizinc_test.py
@@ -7,12 +7,18 @@ from yamlns import namespace as ns
 
 from .minizinc import Menu
 from .minizinc import solve_problem
+from pathlib import Path
 
 # TODO: real fixture ?
 def fixture():
     return ns(
         monday=datetime.datetime(2023, 3, 27),
         idealLoad=ns(
+            goku=4,
+            vegeta=4,
+            krilin=4,
+        ),
+        fullLoad=ns(
             goku=4,
             vegeta=4,
             krilin=4,
@@ -41,6 +47,13 @@ def fixture():
         colors=[],
         extensions=[],
         names=[],
+        holidaysfile = Path('holidays.conf').write_text(
+            "2020-12-24\tNadal\n"
+            "2020-12-25\tNadal\n"
+            "2020-12-26\tNadal\n"
+            "",
+            encoding='utf8',
+        )
     )
 
 
@@ -77,7 +90,7 @@ class Menu_Test(unittest.TestCase):
         # When we get a menu
         config = fixture()
         menu = Menu(config)
-        given_persons = list(config.idealLoad.keys())
+        given_persons = list(config.fullLoad.keys())
         shuffled_persons = menu.names
         # then we have the persons shuffled
         self.assertEqual(len(shuffled_persons), len(given_persons))
@@ -86,8 +99,8 @@ class Menu_Test(unittest.TestCase):
         # and the turns well saved
         for i, torns in enumerate(menu.nTorns):
             name = menu.names[i]
-            ideal_load = config.idealLoad[name]
-            self.assertEqual(ideal_load, torns)
+            full_load = config.fullLoad[name]
+            self.assertEqual(full_load, torns)
 
     def test_indisponibilities(self):
         # Given a config with all the needed parameters
@@ -247,7 +260,7 @@ class Minizinc_Test(unittest.TestCase):
     def test_solve_problem_ko(self):
         # Given well formatted config but no solution
         config = fixture()
-        config.idealLoad.goku = 1
+        config.fullLoad.goku = 1
         # When we call the solve problem method
         solution = solve_problem(config, ['chuffed', 'coin-bc'])
         # Then we do not have a solution


### PR DESCRIPTION
Get fullLoad configuration instead idealLoad because it consider holidays and free days.

Bug: https://trello.com/c/buTaKPG5/340-6902-les-graelles-es-generen-amb-errades-equips-transversals