### PR TITLE
Fix max ningus per turn for user edition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Added minizinc related dependencies: tomato-cooker, minizinc...
 - Fixed auth tests
+- Add `maxNingusPerTurnInEdition` parameter to `config.yaml` and set to 2
 
 ## 4.12.3 2023-05-05
 

--- a/b2bdata/inputs/config-2days2lines.yaml
+++ b/b2bdata/inputs/config-2days2lines.yaml
@@ -31,6 +31,7 @@ descartaNoPrometedores: true
 ignoreOptionalAbsences: true
 deixaEsmorzar: true
 maxNingusPerTurn: 2
+maxNingusPerTurnInEdition: 2
 noVolenEsmorzar:
 - david
 - ningu

--- a/b2bdata/inputs/config-3days6lines.yaml
+++ b/b2bdata/inputs/config-3days6lines.yaml
@@ -32,6 +32,7 @@ descartaNoPrometedores: true
 ignoreOptionalAbsences: true
 deixaEsmorzar: true
 maxNingusPerTurn: 2
+maxNingusPerTurnInEdition: 2
 noVolenEsmorzar:
 - david
 - ningu

--- a/b2bdata/inputs/config-4days6lines.yaml
+++ b/b2bdata/inputs/config-4days6lines.yaml
@@ -34,6 +34,7 @@ descartaNoPrometedores: true
 ignoreOptionalAbsences: true
 deixaEsmorzar: true
 maxNingusPerTurn: 2
+maxNingusPerTurnInEdition: 2
 noVolenEsmorzar:
 - david
 - ningu

--- a/b2bdata/inputs/load-2020-03-02/config.yaml
+++ b/b2bdata/inputs/load-2020-03-02/config.yaml
@@ -45,6 +45,7 @@ costLimit: 200
 descartaNoPrometedores: true
 deixaEsmorzar: true
 maxNingusPerTurn: 2
+maxNingusPerTurnInEdition: 2
 noVolenEsmorzar:
 - david
 - ningu

--- a/b2bdata/inputs/load-and-schedule-2-days/config.yaml
+++ b/b2bdata/inputs/load-and-schedule-2-days/config.yaml
@@ -46,6 +46,7 @@ costLimit: 200
 descartaNoPrometedores: true
 deixaEsmorzar: true
 maxNingusPerTurn: 2
+maxNingusPerTurnInEdition: 2
 noVolenEsmorzar:
 - david
 - ningu

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -36,6 +36,7 @@ costLimit: 200 # Minimum cost to consider, partial solutions above that will be 
 descartaNoPrometedores: true # Prune partial solutions which already have bad penalty (proportional cost is very beyond the limit)
 deixaEsmorzar: true     # True to force free one of the middle time slot to lunch
 maxNingusPerTurn: 2
+maxNingusPerTurnInEdition: 2 # Maxim number of ningus when edit torn by an user
 noVolenEsmorzar: # Specific persons that do not want to lunch
 - ningu
 maximPerTaula: 2   # Maximum number of persons attending phone at the same time on the same table, to avoid cacophonies

--- a/config.yaml
+++ b/config.yaml
@@ -49,6 +49,7 @@ costLimit: 200
 descartaNoPrometedores: true
 deixaEsmorzar: true
 maxNingusPerTurn: 10
+maxNingusPerTurnInEdition: 2
 noVolenEsmorzar:
 - david
 - ningu

--- a/tomatic/api_test.py
+++ b/tomatic/api_test.py
@@ -96,7 +96,6 @@ class Api_Test(unittest.TestCase):
 
     @patch("tomatic.api.schedulestorage.Storage.load")
     @patch("tomatic.api.schedulestorage.Storage.save")
-    @patch.dict('tomatic.schedulestorage.CONFIG', maxNingusPerTurn=2)
     def test_editSlot_ningusLimit(self, mocked_saver, mocked_loader):
         # Given a time table
         old_time_table = self.getTimeTableObjectStructure({

--- a/tomatic/schedulestorage.py
+++ b/tomatic/schedulestorage.py
@@ -174,7 +174,7 @@ class Storage(object):
         timetable = self.load(week)
         # TODO: Ensure day, houri, turni and name are in timetable
         oldName = timetable.timetable[day][int(houri)][int(turni)]
-        if name == 'ningu' and occurrencesInTurn(timetable, day, houri, name) == CONFIG.maxNingusPerTurn:
+        if name == 'ningu' and occurrencesInTurn(timetable, day, houri, name) == CONFIG.maxNingusPerTurnInEdition:
             raise BadEdit("Hi ha masses Ningu en aquest torn")
         timetable.timetable[day][int(houri)][int(turni)] = name
         timetable.overload = timetable.get('overload', ns())


### PR DESCRIPTION
Currently are allowed 10 simultaneus "ningus" when user edit a turn because of the **maxNingusPerTurn** is set to **10**. As this configuration is also used in another processes another configuration **maxNingusPerTurnInEdition** is created to be used only in edition and its value is set to **2**.