### PR TITLE
✨ Oauth configuration moved to dbconfig

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,12 @@
 - Added minizinc related dependencies: tomato-cooker, minizinc...
 - Fixed auth tests
 - Add `maxNingusPerTurnInEdition` parameter to `config.yaml` and set to 2
+- Google OAuth configuration does not need a separate configuration
+  file (config.fastapi) anymore. Moved to dbconfig.
+- Upgrade notes:
+    - Parameters in `config.fastapi` have been moved to `dbconfig.py`
+	- `GOOGLE_CLIENT_ID` -> `tomatic.oauth.client_id` 
+	- `GOOGLE_CLIENT_SECRET` -> `tomatic.oauth.client_secret`
 
 ## 4.12.3 2023-05-05
 

--- a/dbconfig-example.py
+++ b/dbconfig-example.py
@@ -14,8 +14,14 @@ tomatic=ns(
         # YOU SHOULD CHANGE THIS, used to sign authentification and other critical stuff
         secret_key = "Vinga Supers!!",
         expiration = dict(
-           hours=12,
+            hours=12,
         ),
+    ),
+    oauth=ns(
+        # For new deployments, create auth2 client credentials following:
+        # https://blog.hanchon.live/guides/google-login-with-fastapi/
+        client_id='999999999999-l0ng4lp4num3riccod3.apps.googleusercontent.com'
+        client_secret='AAAAA-An0th3r4lph4num3r1c_c0d3'
     ),
     # Choose the PBX backend:
     # - fake: emulates a real PBX

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -75,9 +75,8 @@ sudo ln -s $pwd/crontab /etc/cron.d/tomatic
 - Create a new OAuth2 client id credential
 - In dbconfig:
     - Set `tomatic.jwt.secret_key` to whatever you want
-- Create a `config.fastapi` file with env vars:
-    - Set `GOOGLE_CLIENT_ID` to the client id of the created credential
-    - Set `GOOGLE_CLIENT_SECRET` to the client secret of the created credential
+    - Set `tomatic.oauth.client_id` to the client id of the created credential
+    - Set `tomatic.oauth.client_secret` to the client secret of the created credential
 
 ### Setting up Hangouts notification
 
@@ -140,8 +139,3 @@ $ curl --max-time 1 -X POST  $BASEURL/api/info/ringring --data ext=101 --data ph
 Notice the `--max-time 1` used to avoid stalling the call if the api is down.
 And notice, also, the trailing `|| true` to ensure the call success.
 Both may be needed, depending on how you call this from you PBX.
-
-
-
-
-

--- a/tomatic/auth.py
+++ b/tomatic/auth.py
@@ -5,8 +5,8 @@ from fastapi import APIRouter, HTTPException, Depends, status
 from fastapi.security import OAuth2PasswordBearer
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse
-from authlib.integrations.starlette_client import OAuth, OAuthError
 from starlette.config import Config
+from authlib.integrations.starlette_client import OAuth, OAuthError
 from jose import JWTError, jwt
 from yamlns import namespace as ns
 from consolemsg import error
@@ -35,15 +35,14 @@ def config(key='', default=Ellipsis):
 
 @lru_cache
 def oauth():
-    # TODO: Integrate the configuration with dbconfig
-    config = Config('config.fastapi')
-    oauth = OAuth(config)
+    oauth = OAuth()
     oauth.register(
         name='google',
         server_metadata_url=CONF_URL,
         client_kwargs={
             'scope': 'openid email profile'
-        }
+        },
+        **config('tomatic.oauth')
     )
     return oauth
 
@@ -51,7 +50,7 @@ router = APIRouter()
 
 @router.get('/login')
 async def login(request: Request):
-    redirect_uri = request.url_for('auth')
+    redirect_uri = str(request.url_for('auth'))
     if 'localhost' not in redirect_uri:
         redirect_uri = redirect_uri.replace('http:', 'https:')
     print("Auth redirect uri:", redirect_uri)


### PR DESCRIPTION
This removes the need of having a separate
configuration file config.fastapi for that.
Also, since recent starlette version, url_for
returns URL not a str and must be converted.