### PR TITLE
FIX: pbxirontec stats mkdir

### DIFF
--- a/tomatic/pbx/pbxirontec.py
+++ b/tomatic/pbx/pbxirontec.py
@@ -219,7 +219,7 @@ class Irontec(object):
         calls = self.calls(queue, date)
 
         statsDir = Path('stats')
-        statsDir.mkdir(exists_ok=True)
+        statsDir.mkdir(exist_ok=True)
         ns(calls=calls).dump(statsDir / f"calls-{date}.yaml")
 
 


### PR DESCRIPTION
## Description
A type error was raised when using an incorrect parameter for `mkdir`

## How to check
Launch `tomatic_dailyreport.py` 
* Inspect logs
* Users feedback