### PR TITLE
Fixed turns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## unreleased
+
+- Forced turns can be configured with a time table
+- Minizinc scheduler obeys the forced turns
+- Minizinc with deterministic mode for b2b tests
+- Upgrade notes:
+    - Requires tomato-cooker upgrade tot 0.2
+    - data/forced-turns.yaml should contain a timetable
+      with the forced turns.
+    - suggestion: while there is no ui to edit it
+      we suggest to link to a timetable in the past
+    - If you use a generated timetable for that,
+      remember to change 'ningu' to null, because,
+      'ningu' means a forced empty slot.
+
 ## 4.12.6 2023-05-17
 
 - Minizinc tests fixed

--- a/b2bdata/inputs/load-and-schedule-2-days/config.yaml
+++ b/b2bdata/inputs/load-and-schedule-2-days/config.yaml
@@ -10,6 +10,7 @@ idealLoadNamesRange: carregaideal_noms
 idealLoadValuesRange: carregaideal_valors
 leavesSheet: Baixes
 monitoringFile: taula.html
+forcedTimeTable: forced-turns.yaml
 minizincSolvers:
 - chuffed
 - coin-bc

--- a/b2bdata/inputs/load-and-schedule-2-days/forced-turns.yaml
+++ b/b2bdata/inputs/load-and-schedule-2-days/forced-turns.yaml
@@ -1,0 +1,47 @@
+timetable:
+    dl:
+    - - null
+      - null
+    - - null
+      - null
+    - - null
+      - null
+    - - null
+      - null
+    dm:
+    - - jolie
+      - liza
+    - - null
+      - null
+    - - null
+      - null
+    - - null
+      - null
+    dx:
+    - - null
+      - null
+    - - null
+      - null
+    - - null
+      - null
+    - - null
+      - null
+    dj:
+    - - null
+      - null
+    - - null
+      - null
+    - - null
+      - null
+    - - null
+      - null
+    dv:
+    - - null
+      - null
+    - - null
+      - null
+    - - null
+      - null
+    - - null
+      - null
+

--- a/b2bdata/load-and-schedule-2-days-2-lines-minizinc_carrega-2022-07-11_expected.csv
+++ b/b2bdata/load-and-schedule-2-days-2-lines-minizinc_carrega-2022-07-11_expected.csv
@@ -1,0 +1,17 @@
+alice	1	0
+barbara	0	0
+carol	0	0
+diana	0	1
+elith	0	0
+felicity	0	0
+gemma	1	0
+hellen	0	1
+irma	1	0
+jolie	0	1
+kate	1	0
+liza	2	0
+mary	0	2
+ningu	0	0
+noel	0	1
+olivia	2	0
+petra	0	2

--- a/b2bdata/load-and-schedule-2-days-2-lines-minizinc_carrega-2022-07-11_expected.yaml
+++ b/b2bdata/load-and-schedule-2-days-2-lines-minizinc_carrega-2022-07-11_expected.yaml
@@ -1,0 +1,16 @@
+alice: 1
+barbara: 0
+carol: 0
+diana: 1
+elith: 0
+felicity: 0
+gemma: 1
+hellen: 1
+irma: 1
+jolie: 1
+kate: 1
+liza: 2
+mary: 2
+noel: 1
+olivia: 2
+petra: 2

--- a/b2bdata/load-and-schedule-2-days-2-lines-minizinc_carrega_expected.csv
+++ b/b2bdata/load-and-schedule-2-days-2-lines-minizinc_carrega_expected.csv
@@ -1,0 +1,17 @@
+alice	1	0
+barbara	0	0
+carol	0	0
+diana	0	1
+elith	0	0
+felicity	0	0
+gemma	1	0
+hellen	0	1
+irma	1	0
+jolie	0	1
+kate	1	0
+liza	2	0
+mary	0	2
+ningu	0	0
+noel	0	1
+olivia	2	0
+petra	0	2

--- a/b2bdata/load-and-schedule-2-days-2-lines-minizinc_carrega_expected.yaml
+++ b/b2bdata/load-and-schedule-2-days-2-lines-minizinc_carrega_expected.yaml
@@ -1,0 +1,16 @@
+alice: 1
+barbara: 0
+carol: 0
+diana: 1
+elith: 0
+felicity: 0
+gemma: 1
+hellen: 1
+irma: 1
+jolie: 1
+kate: 1
+liza: 2
+mary: 2
+noel: 1
+olivia: 2
+petra: 2

--- a/b2bdata/load-and-schedule-2-days-2-lines-minizinc_console_expected.log
+++ b/b2bdata/load-and-schedule-2-days-2-lines-minizinc_console_expected.log
@@ -1,0 +1,57 @@
+[34;1m:: Carregant configuració config.yaml...[0m
+[34;1m:: Generant càrrega...[0m
+[34;1m::   Carregant dades...[0m
+[34;1m::     Llegint festius...[0m
+[34;1m::     Llegint carrega ideal...[0m
+[34;1m::     Llegint vacances...[0m
+[34;1m::     Llegint baixes...[0m
+[34;1m::     Llegint altres indisponibilitats...[0m
+[34;1m::     Llegint credits i deutes (bossa d'hores)...[0m
+[34;1m::   Ponderant la ideal...[0m
+[32;1m>>     Surten 26 torns[0m
+[34;1m::   Limitant a la capacitat real...[0m
+[34;1m::   Completant la carrega de 26 a 16...[0m
+[32;1m>>     Carrega assolida 16[0m
+[34;1m::   Compensant deute amb credit...[0m
+La sobrecarrega d'aquesta setmana seria:
+diana: -1.4
+jolie: -1.4
+barbara: -1.2
+hellen: -1.0
+irma: -1.0
+felicity: -0.8
+liza: -0.8
+alice: -0.6
+gemma: -0.6
+kate: -0.6
+carol: -0.4
+noel: -0.2
+mary: 0.4
+olivia: 0.4
+petra: 0.4
+[34;1m:: Desant sobrecàrrega com a overload.yaml[0m
+[34;1m:: Desant càrrega final com a carrega-2022-07-11.yaml[0m
+[34;1m:: Desant càrrega final com a carrega.yaml[0m
+[34;1m:: Desant càrrega distribuida en linies com a carrega-2022-07-11.csv[0m
+[34;1m:: Desant càrrega distribuida en linies com a carrega.csv[0m
+[32;1m>> S'ha aconseguit amb èxit una càrrega de 16 torns[0m
+[34;1m:: Provant amb les indisponibilitats opcionals...[0m
+[32;1m>> Resultat desat a graella-telefons-2022-07-11.yaml[0m
+[32;1m>> Resultat desat a graella-telefons-2022-07-11.html[0m
+Nom	Ideal	Proporcional	Augmentada	CapacitatReal	Topall	AplicatTopall	CobrintTorns	CompensantDeutes	Final	Sobrecarrega	CreditCarregat	CreditInicial	CreditFinal
+alice	4	1.6	1.6	4	2	2	1	1	1	-0.6	0	0	-1
+barbara	3	1.2	1.2	4	1	1	0	0	0	-1.2	0	0	-1
+carol	1	0.4	0.4	4	0	0	0	0	0	-0.4	0	0	0
+diana	6	2.4	2.4	4	2	2	1	1	1	-1.4	0	0	-1
+elith	0	0.0	0.0	4	0	0	0	0	0	0.0	0	0	0
+felicity	2	0.8	0.8	4	1	1	0	0	0	-0.8	0	0	-1
+gemma	4	1.6	1.6	4	2	2	1	1	1	-0.6	0	0	-1
+hellen	5	2.0	2.0	4	2	2	1	1	1	-1.0	0	0	-1
+irma	5	2.0	2.0	4	2	2	1	1	1	-1.0	0	0	-1
+jolie	6	2.4	2.4	4	2	2	1	1	1	-1.4	0	0	-1
+kate	4	1.6	1.6	4	2	2	1	1	1	-0.6	0	0	-1
+liza	7	2.8	2.8	4	3	3	2	2	2	-0.8	0	0	-1
+mary	4	1.6	1.6	4	2	2	2	2	2	0.4	0	0	0
+noel	3	1.2	1.2	4	1	1	1	1	1	-0.2	0	0	0
+olivia	4	1.6	1.6	4	2	2	2	2	2	0.4	0	0	0
+petra	4	1.6	1.6	4	2	2	2	2	2	0.4	0	0	0

--- a/b2bdata/load-and-schedule-2-days-2-lines-minizinc_graella-telefons-2022-07-11_expected.html
+++ b/b2bdata/load-and-schedule-2-days-2-lines-minizinc_graella-telefons-2022-07-11_expected.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html>
+<head>
+<meta charset='utf-8' />
+<style>
+h1 {
+    color: #560;
+}
+td, th {
+	border:1px solid black;
+	width: 8em;
+	text-align: center;
+}
+td:empty { border:0;}
+td { padding: 1ex;}
+.extensions { width: 60%;}
+.extension {
+	display: inline-block;
+	padding: 1ex 0ex;
+	width: 14%;
+	text-align: center;
+	margin: 2pt 0pt;
+	border: 1pt solid black;
+	height: 100%;
+}
+.paused { background-color: #ffffff; }
+
+</style>
+</head>
+<body>
+<h1>Setmana 2022-07-11</h1><table>
+<tr><td></td><th colspan=2>dl</th><td></td><th colspan=2>dm</th><td></td><th colspan=2>dx</th><td></td><th colspan=2>dj</th><td></td><th colspan=2>dv</th></tr>
+<tr><td></td><th>T1</th><th>T2</th><td></td><th>T1</th><th>T2</th><td></td><th>T1</th><th>T2</th><td></td><th>T1</th><th>T2</th><td></td><th>T1</th><th>T2</th></tr>
+<tr><th>09:00-10:15</th>
+<td class='ningu'>Ningu</td>
+<td class='ningu'>Ningu</td>
+<td>&nbsp;</td>
+<td class='jolie'>Jolie</td>
+<td class='liza'>Liza</td>
+<td>&nbsp;</td>
+<td class='ningu'>Ningu</td>
+<td class='ningu'>Ningu</td>
+<td>&nbsp;</td>
+<td class='liza'>Liza</td>
+<td class='mary'>Mary</td>
+<td>&nbsp;</td>
+<td class='ningu'>Ningu</td>
+<td class='ningu'>Ningu</td>
+</tr>
+<tr><th>10:15-11:30</th>
+<td class='ningu'>Ningu</td>
+<td class='ningu'>Ningu</td>
+<td>&nbsp;</td>
+<td class='alice'>Alice</td>
+<td class='diana'>Diana</td>
+<td>&nbsp;</td>
+<td class='ningu'>Ningu</td>
+<td class='ningu'>Ningu</td>
+<td>&nbsp;</td>
+<td class='mary'>Mary</td>
+<td class='noel'>Noel</td>
+<td>&nbsp;</td>
+<td class='ningu'>Ningu</td>
+<td class='ningu'>Ningu</td>
+</tr>
+<tr><th>11:30-12:45</th>
+<td class='ningu'>Ningu</td>
+<td class='ningu'>Ningu</td>
+<td>&nbsp;</td>
+<td class='gemma'>Gemma</td>
+<td class='hellen'>Hellen</td>
+<td>&nbsp;</td>
+<td class='ningu'>Ningu</td>
+<td class='ningu'>Ningu</td>
+<td>&nbsp;</td>
+<td class='olivia'>Olivia</td>
+<td class='petra'>Petra</td>
+<td>&nbsp;</td>
+<td class='ningu'>Ningu</td>
+<td class='ningu'>Ningu</td>
+</tr>
+<tr><th>12:45-14:00</th>
+<td class='ningu'>Ningu</td>
+<td class='ningu'>Ningu</td>
+<td>&nbsp;</td>
+<td class='irma'>Irma</td>
+<td class='kate'>Kate</td>
+<td>&nbsp;</td>
+<td class='ningu'>Ningu</td>
+<td class='ningu'>Ningu</td>
+<td>&nbsp;</td>
+<td class='olivia'>Olivia</td>
+<td class='petra'>Petra</td>
+<td>&nbsp;</td>
+<td class='ningu'>Ningu</td>
+<td class='ningu'>Ningu</td>
+</tr>
+</table><h3>Penalitzacions</h3>
+<p>Penalitzacio: 16</p>
+<ul>
+
+</ul>
+<h3>Extensions</h3>
+<div class="extensions">
+
+</div></body>
+</html>

--- a/b2bdata/load-and-schedule-2-days-2-lines-minizinc_graella-telefons-2022-07-11_expected.yaml
+++ b/b2bdata/load-and-schedule-2-days-2-lines-minizinc_graella-telefons-2022-07-11_expected.yaml
@@ -1,0 +1,69 @@
+week: '2022-07-11'
+days:
+- dl
+- dm
+- dx
+- dj
+- dv
+hours:
+- 09:00
+- '10:15'
+- '11:30'
+- '12:45'
+- '14:00'
+turns:
+- T1
+- T2
+timetable:
+  dl:
+  - - ningu
+    - ningu
+  - - ningu
+    - ningu
+  - - ningu
+    - ningu
+  - - ningu
+    - ningu
+  dm:
+  - - jolie
+    - liza
+  - - alice
+    - diana
+  - - gemma
+    - hellen
+  - - irma
+    - kate
+  dx:
+  - - ningu
+    - ningu
+  - - ningu
+    - ningu
+  - - ningu
+    - ningu
+  - - ningu
+    - ningu
+  dj:
+  - - liza
+    - mary
+  - - mary
+    - noel
+  - - olivia
+    - petra
+  - - olivia
+    - petra
+  dv:
+  - - ningu
+    - ningu
+  - - ningu
+    - ningu
+  - - ningu
+    - ningu
+  - - ningu
+    - ningu
+colors: {}
+extensions: {}
+names: {}
+overload: {}
+penalties: []
+cost: 16
+log: []

--- a/b2bdata/load-and-schedule-2-days-2-lines-minizinc_overload_expected.yaml
+++ b/b2bdata/load-and-schedule-2-days-2-lines-minizinc_overload_expected.yaml
@@ -1,0 +1,16 @@
+alice: -0.6
+barbara: -1.2
+carol: -0.4
+diana: -1.4
+elith: 0.0
+felicity: -0.8
+gemma: -0.6
+hellen: -1.0
+irma: -1.0
+jolie: -1.4
+kate: -0.6
+liza: -0.8
+mary: 0.4
+noel: -0.2
+olivia: 0.4
+petra: 0.4

--- a/b2bdata/load-and-schedule-2-days-2-lines-minizinc_ponderatedideal-2022-07-11_expected.yaml
+++ b/b2bdata/load-and-schedule-2-days-2-lines-minizinc_ponderatedideal-2022-07-11_expected.yaml
@@ -1,0 +1,16 @@
+alice: 1.6
+barbara: 1.2
+carol: 0.4
+diana: 2.4
+elith: 0.0
+felicity: 0.8
+gemma: 1.6
+hellen: 2.0
+irma: 2.0
+jolie: 2.4
+kate: 1.6
+liza: 2.8
+mary: 1.6
+noel: 1.2
+olivia: 1.6
+petra: 1.6

--- a/b2bdata/load-and-schedule-2-days-2-lines-minizinc_status_expected.yaml
+++ b/b2bdata/load-and-schedule-2-days-2-lines-minizinc_status_expected.yaml
@@ -1,0 +1,6 @@
+totalCells: -1
+completedCells: -1
+solutionCost: 0
+unfilledCell: Complete
+busyReasons: {}
+penalties: []

--- a/back2back.yaml
+++ b/back2back.yaml
@@ -134,3 +134,28 @@ testcases:
         - graella-telefons.log
         - status.yaml
 
+    load-and-schedule-2-days-2-lines-minizinc:
+        command: |
+            cd b2bdata/inputs/load-and-schedule-2-days/ ;
+            tomatic_scheduler_minizinc.py 2022-07-11 \
+                --keep \
+                --config-file config.yaml \
+                --personsfile persons.yaml \
+                --idealshifts idealshifts.yaml \
+                --overload overload.yaml \
+                --clusterize \
+                --deterministic \
+                --lines 2 \
+                --compute-shifts \
+                2>&1 | tee console.log && \
+                sed -i '/timeOfLastSolution/d' status.yaml
+        outputs:
+        - b2bdata/inputs/load-and-schedule-2-days/console.log
+        - b2bdata/inputs/load-and-schedule-2-days/overload.yaml
+        - b2bdata/inputs/load-and-schedule-2-days/ponderatedideal-2022-07-11.yaml
+        - b2bdata/inputs/load-and-schedule-2-days/carrega-2022-07-11.yaml
+        - b2bdata/inputs/load-and-schedule-2-days/carrega-2022-07-11.csv
+        - b2bdata/inputs/load-and-schedule-2-days/carrega.csv
+        - b2bdata/inputs/load-and-schedule-2-days/graella-telefons-2022-07-11.html
+        - b2bdata/inputs/load-and-schedule-2-days/graella-telefons-2022-07-11.yaml
+        - b2bdata/inputs/load-and-schedule-2-days/status.yaml

--- a/back2back.yaml
+++ b/back2back.yaml
@@ -151,11 +151,12 @@ testcases:
                 sed -i '/timeOfLastSolution/d' status.yaml
         outputs:
         - b2bdata/inputs/load-and-schedule-2-days/console.log
-        - b2bdata/inputs/load-and-schedule-2-days/overload.yaml
         - b2bdata/inputs/load-and-schedule-2-days/ponderatedideal-2022-07-11.yaml
         - b2bdata/inputs/load-and-schedule-2-days/carrega-2022-07-11.yaml
         - b2bdata/inputs/load-and-schedule-2-days/carrega-2022-07-11.csv
         - b2bdata/inputs/load-and-schedule-2-days/carrega.csv
+        - b2bdata/inputs/load-and-schedule-2-days/carrega.yaml
+        - b2bdata/inputs/load-and-schedule-2-days/overload.yaml
         - b2bdata/inputs/load-and-schedule-2-days/graella-telefons-2022-07-11.html
         - b2bdata/inputs/load-and-schedule-2-days/graella-telefons-2022-07-11.yaml
         - b2bdata/inputs/load-and-schedule-2-days/status.yaml

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         'charset-normalizer<3', # request and httpio complains once 3.x is out
         'httplib2', # Google chat code
         'backports.zoneinfo; python_version < "3.9"', # Py3.8 support for Py3.9 zoneinfo
-        'tomato-cooker',
+        'tomato-cooker>=0.2',
         'pandas',
         'matplotlib',
     #],

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         'charset-normalizer<3', # request and httpio complains once 3.x is out
         'httplib2', # Google chat code
         'backports.zoneinfo; python_version < "3.9"', # Py3.8 support for Py3.9 zoneinfo
-        'tomato-cooker>=0.2',
+        'tomato-cooker>=0.2.1',
         'pandas',
         'matplotlib',
     #],

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'scripts/tomatic_timetablelauncher.py',
         'scripts/tomatic_says.py',
         'scripts/tomatic_scheduler.py',
+        'scripts/tomatic_scheduler_minizinc.py',
         'scripts/tomatic_shiftload.py',
         'scripts/tomatic_stats.py',
         'scripts/tomatic_uploadcases.py',

--- a/tomatic/minizinc.py
+++ b/tomatic/minizinc.py
@@ -24,6 +24,7 @@ class Menu:
 
     def __init__(self, config):
         laborable_days = laborableWeekDays(config.monday)
+        self.deterministic = config.deterministic
         self.nPersons = len(config.finalLoad)
         self.nLines = config.nTelefons
         self.nHours = len(config.hours) - 1
@@ -37,7 +38,10 @@ class Menu:
         self.forcedTurns = self._forcedTurns(config)
 
     def _saveNamesAndTurns(self, fulls):
-        self.names = random.sample(list(fulls), len(fulls))
+        if self.deterministic:
+                self.names = list(sorted(fulls))
+        else:
+                self.names = random.sample(list(fulls), len(fulls))
         self.nTorns = [fulls[p] for p in self.names]
 
     def _indisponibilities(self, config):
@@ -133,7 +137,7 @@ def solve_problem(config, solvers):
     # create an instance of the cooker
     tomato_cooker = GrillTomatoCooker(tomatic.MODEL_DEFINITION_PATH, solvers)
     # Now, we can solve the problem
-    solution = asyncio.run(tomato_cooker.cook(tomatic_problem))
+    solution = asyncio.run(tomato_cooker.cook(tomatic_problem, deterministic=config.deterministic))
     return menu.translate(solution, config) if solution else False
 
 
@@ -146,6 +150,7 @@ def main():
         args.certificate,
         args.holidays,
         args.lines,
+        args.deterministic,
     )
     # TODO: check where to save this
     target_date = args.date or config.data.monday

--- a/tomatic/minizinc.py
+++ b/tomatic/minizinc.py
@@ -58,6 +58,13 @@ class Menu:
 
     def _forcedTurns(self, config):
         forcedTurns = [set() for _ in range(self.nPersones * self.nDies)]
+        for ((day, hour, line), person) in config.get('forced',{}).items():
+            if day not in self.laborable_days: continue
+
+            iday = self.laborable_days.index(day)
+            iperson = self.names.index(person)
+            idx = iperson * self.nDies + iday
+            forcedTurns[idx].add(hour+1)
         return forcedTurns
 
     def ingredients(self):

--- a/tomatic/minizinc.py
+++ b/tomatic/minizinc.py
@@ -37,12 +37,8 @@ class Menu:
         self.forcedTurns = self._forcedTurns(config)
 
     def _saveNamesAndTurns(self, fulls):
-        persons = list(fulls.keys())
-        random.shuffle(persons)
-        shuffled_fulls = [(key, fulls[key]) for key in persons]
-        names, turns = zip(*shuffled_fulls)
-        self.nTorns  = list(turns)
-        self.names = list(names)
+        self.names = random.sample(list(fulls), len(fulls))
+        self.nTorns = [fulls[p] for p in self.names]
 
     def _indisponibilities(self, config):
         persons_indisponibilities = {
@@ -79,6 +75,7 @@ class Menu:
             nTorns=self.nTorns,
             indisponibilitats=self.indisponibilitats,
             forcedTurns=self.forcedTurns,
+            names=self.names,
         )
 
     def translate(self, solution, config):
@@ -93,8 +90,8 @@ class Menu:
 
         for day, turns in zip(self.laborable_days, solution.solution.ocupacioSlot):
             for turn_i, turn in enumerate(turns):
-                for slot_i, person in enumerate(turn):
-                    timetable[day][turn_i][slot_i] = self.names[person-1]
+                for slot_i, person in enumerate(sorted(turn)):
+                    timetable[day][turn_i][slot_i] = person
 
         result = ns(
             week=f'{config.monday}',

--- a/tomatic/minizinc.py
+++ b/tomatic/minizinc.py
@@ -60,6 +60,7 @@ class Menu:
         forcedTurns = [set() for _ in range(self.nPersones * self.nDies)]
         for ((day, hour, line), person) in config.get('forced',{}).items():
             if day not in self.laborable_days: continue
+            if person not in self.names: continue
 
             iday = self.laborable_days.index(day)
             iperson = self.names.index(person)

--- a/tomatic/minizinc.py
+++ b/tomatic/minizinc.py
@@ -24,7 +24,7 @@ class Menu:
 
     def __init__(self, config):
         laborable_days = laborableWeekDays(config.monday)
-        self.deterministic = config.deterministic
+        self.deterministic = config.get('deterministic', False)
         self.nPersons = len(config.finalLoad)
         self.nLines = config.nTelefons
         self.nHours = len(config.hours) - 1

--- a/tomatic/minizinc.py
+++ b/tomatic/minizinc.py
@@ -34,7 +34,7 @@ class Menu:
         self.laborable_days = laborable_days
         self.WEEKDAY = { day: i for i, day in enumerate(laborable_days) }
         self.indisponibilitats = self._indisponibilities(config)
-        self.forcedTurns = self._forcedTurns()
+        self.forcedTurns = self._forcedTurns(config)
 
     def _saveNamesAndTurns(self, fulls):
         persons = list(fulls.keys())
@@ -56,8 +56,7 @@ class Menu:
             indisponibilities.extend(persons_indisponibilities[name])
         return indisponibilities
 
-    # TODO: Read forcedTurns from 🕳️
-    def _forcedTurns(self):
+    def _forcedTurns(self, config):
         forcedTurns = [set() for _ in range(self.nPersones * self.nDies)]
         return forcedTurns
 

--- a/tomatic/minizinc.py
+++ b/tomatic/minizinc.py
@@ -34,7 +34,7 @@ class Menu:
         self.laborable_days = laborable_days
         self.WEEKDAY = { day: i for i, day in enumerate(laborable_days) }
         self.indisponibilitats = self._indisponibilities(config)
-        self.preferencies = self._preferences()
+        self.forcedTurns = self._forcedTurns()
 
     def _saveNamesAndTurns(self, fulls):
         persons = list(fulls.keys())
@@ -56,10 +56,10 @@ class Menu:
             indisponibilities.extend(persons_indisponibilities[name])
         return indisponibilities
 
-    # TODO: Read preferences from 🕳️
-    def _preferences(self):
-        preferences = [set() for _ in range(self.nPersones * self.nDies)]
-        return preferences
+    # TODO: Read forcedTurns from 🕳️
+    def _forcedTurns(self):
+        forcedTurns = [set() for _ in range(self.nPersones * self.nDies)]
+        return forcedTurns
 
     def ingredients(self):
         return dict(
@@ -71,7 +71,7 @@ class Menu:
             maxTorns=self.maxTorns,
             nTorns=self.nTorns,
             indisponibilitats=self.indisponibilitats,
-            preferencies=self.preferencies
+            forcedTurns=self.forcedTurns
         )
 
     def translate(self, solution, config):

--- a/tomatic/minizinc.py
+++ b/tomatic/minizinc.py
@@ -27,7 +27,7 @@ class Menu:
         self.nPersons = len(config.finalLoad)
         self.nLines = config.nTelefons
         self.nHours = len(config.hours) - 1
-        self.nNingus = config.nNingusMinizinc
+        self.nNingus = config.get("nNingusMinizinc", self.nLines)
         self.nDays = len(laborable_days)
         self.maxTorns = config.maximHoresDiariesGeneral
         self._saveNamesAndTurns(config.finalLoad)
@@ -144,7 +144,8 @@ def main():
         args.date,
         args.keep,
         args.certificate,
-        args.holidays
+        args.holidays,
+        args.lines,
     )
     # TODO: check where to save this
     target_date = args.date or config.data.monday

--- a/tomatic/minizinc.py
+++ b/tomatic/minizinc.py
@@ -24,11 +24,11 @@ class Menu:
 
     def __init__(self, config):
         laborable_days = laborableWeekDays(config.monday)
-        self.nPersones = len(config.finalLoad)
-        self.nLinies = config.nTelefons
-        self.nSlots = len(config.hours) - 1
+        self.nPersons = len(config.finalLoad)
+        self.nLines = config.nTelefons
+        self.nHours = len(config.hours) - 1
         self.nNingus = config.nNingusMinizinc
-        self.nDies = len(laborable_days)
+        self.nDays = len(laborable_days)
         self.maxTorns = config.maximHoresDiariesGeneral
         self._saveNamesAndTurns(config.finalLoad)
         self.laborable_days = laborable_days
@@ -46,7 +46,7 @@ class Menu:
 
     def _indisponibilities(self, config):
         persons_indisponibilities = {
-            name: [set() for _ in range(self.nDies)] for name in self.names
+            name: [set() for _ in range(self.nDays)] for name in self.names
         }
         for day, turn, name in config.busyTable:
             if config.busyTable[(day, turn, name)] and day in self.laborable_days:
@@ -57,28 +57,28 @@ class Menu:
         return indisponibilities
 
     def _forcedTurns(self, config):
-        forcedTurns = [set() for _ in range(self.nPersones * self.nDies)]
+        forcedTurns = [set() for _ in range(self.nPersons * self.nDays)]
         for ((day, hour, line), person) in config.get('forced',{}).items():
             if day not in self.laborable_days: continue
             if person not in self.names: continue
 
             iday = self.laborable_days.index(day)
             iperson = self.names.index(person)
-            idx = iperson * self.nDies + iday
+            idx = iperson * self.nDays + iday
             forcedTurns[idx].add(hour+1)
         return forcedTurns
 
     def ingredients(self):
         return dict(
-            nPersones=self.nPersones,
-            nLinies=self.nLinies,
-            nSlots=self.nSlots,
+            nPersons=self.nPersons,
+            nLines=self.nLines,
+            nHours=self.nHours,
             nNingus=self.nNingus,
-            nDies=self.nDies,
+            nDays=self.nDays,
             maxTorns=self.maxTorns,
             nTorns=self.nTorns,
             indisponibilitats=self.indisponibilitats,
-            forcedTurns=self.forcedTurns
+            forcedTurns=self.forcedTurns,
         )
 
     def translate(self, solution, config):
@@ -86,8 +86,8 @@ class Menu:
         timetable = {
             day: [
                 [
-                    self.NINGU for _ in range(self.nLinies)
-                ] for _ in range(self.nSlots)
+                    self.NINGU for _ in range(self.nLines)
+                ] for _ in range(self.nHours)
             ] for day in days
         }
 

--- a/tomatic/minizinc.py
+++ b/tomatic/minizinc.py
@@ -137,7 +137,7 @@ def solve_problem(config, solvers):
     # create an instance of the cooker
     tomato_cooker = GrillTomatoCooker(tomatic.MODEL_DEFINITION_PATH, solvers)
     # Now, we can solve the problem
-    solution = asyncio.run(tomato_cooker.cook(tomatic_problem, deterministic=config.deterministic))
+    solution = asyncio.run(tomato_cooker.cook(tomatic_problem, deterministic=config.get('deterministic', False)))
     return menu.translate(solution, config) if solution else False
 
 

--- a/tomatic/minizinc_test.py
+++ b/tomatic/minizinc_test.py
@@ -15,11 +15,6 @@ from pathlib import Path
 def fixture():
     return ns(
         monday=datetime.datetime(2023, 3, 27),
-        idealLoad=ns(
-            goku=4,
-            vegeta=4,
-            krilin=4,
-        ),
         finalLoad=ns(
             goku=4,
             vegeta=4,

--- a/tomatic/minizinc_test.py
+++ b/tomatic/minizinc_test.py
@@ -240,15 +240,14 @@ class Menu_Test(unittest.TestCase):
         # Given a solution and a config
         config = fixture()
         menu = Menu(config)
-        menu.names = ['goku', 'vegeta', 'krilin']
         solution = ns(
             solution=ns(
                 ocupacioSlot=[
-                    [{3, 2}],  # dl
-                    [{3, 1}],  # dm
-                    [{1, 2}],  # dx
-                    [{1, 2}],  # dj
-                    [{3, 2}],  # dv
+                    [{'krilin', 'vegeta'}],  # dl
+                    [{'krilin', 'goku'}],  # dm
+                    [{'goku', 'vegeta'}],  # dx
+                    [{'goku', 'vegeta'}],  # dj
+                    [{'krilin', 'vegeta'}],  # dv
                 ],
                 totalTorns=10
             )
@@ -260,11 +259,11 @@ class Menu_Test(unittest.TestCase):
         # Then we get the result as the expected namespace
         expected = make_minizinc_ns_result(
             timetable={
-                'dl': [['vegeta', 'krilin']],
+                'dl': [['krilin', 'vegeta']],
                 'dm': [['goku', 'krilin']],
                 'dx': [['goku', 'vegeta']],
                 'dj': [['goku', 'vegeta']],
-                'dv': [['vegeta', 'krilin']]
+                'dv': [['krilin', 'vegeta']],
             },
             cost=10
         )
@@ -275,15 +274,14 @@ class Menu_Test(unittest.TestCase):
         # Given a solution and a config
         config = fixture()
         menu = Menu(config)
-        menu.names = ['goku', 'vegeta', 'krilin']
         solution = ns(
             solution=ns(
                 ocupacioSlot=[
-                    [{3}],  # dl
-                    [{3, 1}],  # dm
-                    [{1, 2}],  # dx
-                    [{1}],  # dj
-                    [{3, 2}],  # dv
+                    [{'krilin'}],  # dl
+                    [{'krilin', 'goku'}],  # dm
+                    [{'goku', 'vegeta'}],  # dx
+                    [{'goku'}],  # dj
+                    [{'krilin', 'vegeta'}],  # dv
                 ],
                 totalTorns=10
             )
@@ -299,7 +297,7 @@ class Menu_Test(unittest.TestCase):
                 'dm': [['goku', 'krilin']],
                 'dx': [['goku', 'vegeta']],
                 'dj': [['goku', 'ningu']],
-                'dv': [['vegeta', 'krilin']]
+                'dv': [['krilin', 'vegeta']]
             },
             cost=10
         )
@@ -310,15 +308,14 @@ class Menu_Test(unittest.TestCase):
         # Given a solution and a config with one holiday
         config = fixture()
         menu = Menu(config)
-        menu.names = ['goku', 'vegeta', 'krilin']
         menu.laborable_days = ['dl', 'dm', 'dx', 'dv']
         solution = ns(
             solution=ns(
                 ocupacioSlot=[
-                    [{3}],  # dl
-                    [{3, 1}],  # dm
-                    [{1, 2}],  # dx
-                    [{1}],  # dv
+                    [{'krilin'}],  # dl
+                    [{'krilin', 'goku'}],  # dm
+                    [{'goku', 'vegeta'}],  # dx
+                    [{'goku'}],  # dv
                 ],
                 totalTorns=8
             )

--- a/tomatic/minizinc_test.py
+++ b/tomatic/minizinc_test.py
@@ -137,6 +137,18 @@ class Menu_Test(unittest.TestCase):
             )
         self.assertEqual(expected_indisponibilities, menu.indisponibilitats)
 
+    def test_forcedTurns_whenMissing(self):
+        # Given a config with all the needed parameters
+        # When we get a menu
+        nDays = 5 # week with no festivities
+        config = fixture()
+        menu = Menu(config)
+
+        self.assertEqual(menu.forcedTurns, [
+            set()
+            for _ in range(len(config.finalLoad) * nDays)
+        ])
+
     @patch("tomatic.minizinc.laborableWeekDays")
     def test_indisponibilities_with_holidays(self, mocked_laborableWeekDays):
         mocked_laborableWeekDays.return_value = ['dl', 'dm', 'dx', 'dj']

--- a/tomatic/minizinc_test.py
+++ b/tomatic/minizinc_test.py
@@ -161,7 +161,7 @@ class Menu_Test(unittest.TestCase):
         line = 3
         config = fixture()
         config.forced = {
-            (day, hour-1 , line): 'goku'
+            (day, hour-1 , line): person
         }
         menu = Menu(config)
         expectation = [
@@ -186,7 +186,27 @@ class Menu_Test(unittest.TestCase):
         line = 3
         config = fixture()
         config.forced = {
-            (day, hour-1 , line): 'goku'
+            (day, hour-1 , line): person
+        }
+        menu = Menu(config)
+        expectation = [
+            set()
+            for idx in range(len(config.finalLoad) * nDays)
+        ]
+        self.assertEqual(menu.forcedTurns, expectation)
+
+    def test_forcedTurns_withAMissingPerson(self):
+        # Given a config with all the needed parameters
+        # When we get a menu
+        nDays = 5 # week with no festivities
+        day = 'dm'
+        iday = fullWeekdays.index(day)
+        person = 'mortadelo' # Not in Dragon Ball
+        hour = 1
+        line = 3
+        config = fixture()
+        config.forced = {
+            (day, hour-1 , line): person
         }
         menu = Menu(config)
         expectation = [

--- a/tomatic/minizinc_test.py
+++ b/tomatic/minizinc_test.py
@@ -7,6 +7,7 @@ from yamlns import namespace as ns
 
 from .minizinc import Menu
 from .minizinc import solve_problem
+from .busy import weekdays as fullWeekdays
 from pathlib import Path
 
 
@@ -148,6 +149,51 @@ class Menu_Test(unittest.TestCase):
             set()
             for _ in range(len(config.finalLoad) * nDays)
         ])
+
+    def test_forcedTurns_withAForcedTurn(self):
+        # Given a config with all the needed parameters
+        # When we get a menu
+        nDays = 5 # week with no festivities
+        day = 'dm'
+        iday = fullWeekdays.index(day)
+        person = 'goku'
+        hour = 1
+        line = 3
+        config = fixture()
+        config.forced = {
+            (day, hour-1 , line): 'goku'
+        }
+        menu = Menu(config)
+        expectation = [
+            set()
+            for idx in range(len(config.finalLoad) * nDays)
+        ]
+        iperson = menu.names.index(person)
+        expectation[iday + nDays*iperson] = {hour}
+
+        self.assertEqual(menu.forcedTurns, expectation)
+
+    @patch("tomatic.minizinc.laborableWeekDays")
+    def test_forcedTurns_withAForcedTurn_inAFestivity_ignored(self, mocked_laborableWeekDays):
+        mocked_laborableWeekDays.return_value = ['dl', 'dx', 'dj', 'dv'] # dm removed
+        # Given a config with all the needed parameters
+        # When we get a menu
+        nDays = 4 # week with a festivity
+        day = 'dm'
+        iday = fullWeekdays.index(day)
+        person = 'goku'
+        hour = 1
+        line = 3
+        config = fixture()
+        config.forced = {
+            (day, hour-1 , line): 'goku'
+        }
+        menu = Menu(config)
+        expectation = [
+            set()
+            for idx in range(len(config.finalLoad) * nDays)
+        ]
+        self.assertEqual(menu.forcedTurns, expectation)
 
     @patch("tomatic.minizinc.laborableWeekDays")
     def test_indisponibilities_with_holidays(self, mocked_laborableWeekDays):

--- a/tomatic/plannerexecution.py
+++ b/tomatic/plannerexecution.py
@@ -58,7 +58,7 @@ class PlannerExecution(Execution):
 
         forcedTurnsFile = self.configPath/'data'/'forced-turns.yaml'
         if forcedTurnsFile.exists():
-            config.forcedTimetable = 'forced-turns.yaml'
+            config.forcedTimeTable = 'forced-turns.yaml'
             (self.path/'forced-turns.yaml').symlink_to(forcedTurnsFile.resolve())
 
         config.dump(self.path/'config.yaml')

--- a/tomatic/plannerexecution.py
+++ b/tomatic/plannerexecution.py
@@ -55,6 +55,12 @@ class PlannerExecution(Execution):
             if x not in self.searchDays
         ]
         config.maxOverload = 0
+
+        forcedTurnsFile = self.configPath/'data'/'forced-turns.yaml'
+        if forcedTurnsFile.exists():
+            config.forcedTimetable = 'forced-turns.yaml'
+            (self.path/'forced-turns.yaml').symlink_to(forcedTurnsFile.resolve())
+
         config.dump(self.path/'config.yaml')
         (self.path/'drive-certificate.json').symlink_to(
             (self.configPath/'drive-certificate.json').resolve())

--- a/tomatic/scenario_config.py
+++ b/tomatic/scenario_config.py
@@ -1,4 +1,4 @@
-from consolemsg import step, error
+from consolemsg import step, error, warn
 from yamlns import namespace as ns
 import datetime
 from .retriever import addDays
@@ -51,8 +51,11 @@ class Config:
                 not keep and downloadShiftCredit(self.data)
                 self.update_shifts()
             if self.data.get('forcedTimeTable'):
+                step(f"Lodading forced turns from {self.data.get('forcedTimeTable')}...")
                 forcedTimeTable = ns.load(self.data.get('forcedTimeTable'))
                 self.data.forced = timetable2forced(forcedTimeTable.timetable)
+            else:
+                warn("No forcedTimeTable configured")
         except Exception as e:
             error("{}", e)
             raise

--- a/tomatic/scenario_config.py
+++ b/tomatic/scenario_config.py
@@ -3,6 +3,7 @@ from yamlns import namespace as ns
 import datetime
 from .retriever import addDays
 from .shiftload import ShiftLoadComputer
+from .scheduling import timetable2forced
 from tomatic.retriever import (
     downloadPersons,
     downloadLeaves,
@@ -49,6 +50,9 @@ class Config:
                 not keep and step("Baixant bossa d'hores del tomatic...")
                 not keep and downloadShiftCredit(self.data)
                 self.update_shifts()
+            if self.data.get('forcedTimeTable'):
+                forcedTimeTable = ns.load(self.data.get('forcedTimeTable'))
+                self.data.forced = timetable2forced(forcedTimeTable.timetable)
         except Exception as e:
             error("{}", e)
             raise

--- a/tomatic/scenario_config.py
+++ b/tomatic/scenario_config.py
@@ -70,6 +70,12 @@ class Config:
             forgive = config.get('forgive', False), # TODO: Pass forgive from args to config
             inclusters = config.get('clusterize', False), #TODO: Pass clusterize from args to config
         )
+        args = ns(
+            weekshifts='carrega.yaml',
+            overload='overload.yaml',
+            summary=None,
+        )
+        computer.outputResults(args)
 
         config.finalLoad = computer.final
         config.busyTable = setup.busyTable._table

--- a/tomatic/scenario_config.py
+++ b/tomatic/scenario_config.py
@@ -19,7 +19,7 @@ from tomatic.retriever import (
 
 class Config:
 
-    def __init__(self, config_file, date, keep, certificate, holidays):
+    def __init__(self, config_file, date, keep, certificate, holidays, nLines=None):
         step('Carregant configuració {}...', config_file)
         try:
             self.data = ns.load(config_file)
@@ -27,22 +27,24 @@ class Config:
             error("Error llegint {}: {}", config_file, e)
             raise
         try:
+            if nLines is not None:
+                self.data.nTelefons = nLines
             self._update_monday(date)
             not keep and downloadPersons(self.data)
             self._update_persons()
             if not self.data.get('idealshifts'):
                 self.data.idealshifts = 'idealshifts.yaml'
                 not keep and downloadIdealLoad(self.data, certificate)
-            if not self.data.get('weekShifts') and not self.data.computeShifts:
+            if not self.data.get('weekShifts') and not self.data.get("computeShifts"):
                 self.data.weekShifts = 'carrega.csv'
                 not keep and downloadShiftload(self.data)
-            if not self.data.computeShifts:
+            if not self.data.get("computeShifts"):
                 self.data.overloadfile = "overload-{}.yaml".format(self.data.monday)
                 not keep and downloadOverload(self.data)
             not keep and self._download_leaves(certificate)
             if not self.data.get('busyFiles'):
                 not keep and self._download_busy(holidays)
-            if self.data.computeShifts:
+            if self.data.get("computeShifts"):
                 not keep and step("Baixant bossa d'hores del tomatic...")
                 not keep and downloadShiftCredit(self.data)
                 self.update_shifts()

--- a/tomatic/scenario_config.py
+++ b/tomatic/scenario_config.py
@@ -19,7 +19,7 @@ from tomatic.retriever import (
 
 class Config:
 
-    def __init__(self, config_file, date, keep, certificate, holidays, nLines=None):
+    def __init__(self, config_file, date, keep, certificate, holidays, nLines=None, deterministic=False):
         step('Carregant configuració {}...', config_file)
         try:
             self.data = ns.load(config_file)
@@ -27,6 +27,7 @@ class Config:
             error("Error llegint {}: {}", config_file, e)
             raise
         try:
+            self.data.deterministic = deterministic
             if nLines is not None:
                 self.data.nTelefons = nLines
             self._update_monday(date)

--- a/tomatic/scheduling.py
+++ b/tomatic/scheduling.py
@@ -135,6 +135,7 @@ def timetable2forced(timetable):
     for day, hours in timetable.items():
         for hour, lines in enumerate(hours):
             for line, person in enumerate(lines):
+                if person is None: continue
                 result[day, hour, line] = person
     return result
 

--- a/tomatic/scheduling.py
+++ b/tomatic/scheduling.py
@@ -130,7 +130,13 @@ def solution2schedule(config, solution, date=None):
     result.names = config.get('names', {})
     return result
 
-
+def timetable2forced(timetable):
+    result = ns()
+    for day, hours in timetable.items():
+        for hour, lines in enumerate(hours):
+            for line, person in enumerate(lines):
+                result[day, hour, line] = person
+    return result
 
 
 # vim: ts=4 sw=4 et

--- a/tomatic/scheduling_test.py
+++ b/tomatic/scheduling_test.py
@@ -12,6 +12,7 @@ from .scheduling import (
     nextweek,
     choosers,
     Scheduling,
+    timetable2forced,
 )
 
 class Scheduling_Test(unittest.TestCase):
@@ -947,6 +948,104 @@ class Scheduling_Test(unittest.TestCase):
                   cesar:  César
                   victor: Víctor
             """)
+
+    def test_timetable2forcedTurns_baseCase(self):
+        timetable = ns.loads("""\
+              dl:
+              - - jordi
+                - tania
+              - - tania
+                - silvia
+              - - judith
+                - ana
+              - - ana
+                - erola
+              dm:
+              - - pere
+                - victor
+              - - carles
+                - ana
+              - - joan
+                - eduard
+              - - david
+                - monica
+              dx:
+              - - yaiza
+                - pere
+              - - erola
+                - marta
+              - - victor
+                - jordi
+              - - eduard
+                - victor
+              dj:
+              - - judith
+                - carles
+              - - silvia
+                - judith
+              - - monica
+                - judit
+              - - judit
+                - joan
+              dv:
+              - - ana
+                - judith
+              - - jordi
+                - ana
+              - - victor
+                - carles
+              - - marta
+                - silvia
+        """)
+        forced = timetable2forced(timetable)
+        self.assertNsEqual(forced, """\
+              [dl, 0, 0]: jordi
+              [dl, 0, 1]: tania
+              [dl, 1, 0]: tania
+              [dl, 1, 1]: silvia
+              [dl, 2, 0]: judith
+              [dl, 2, 1]: ana
+              [dl, 3, 0]: ana
+              [dl, 3, 1]: erola
+
+              [dm, 0, 0]: pere
+              [dm, 0, 1]: victor
+              [dm, 1, 0]: carles
+              [dm, 1, 1]: ana
+              [dm, 2, 0]: joan
+              [dm, 2, 1]: eduard
+              [dm, 3, 0]: david
+              [dm, 3, 1]: monica
+
+              [dx, 0, 0]: yaiza
+              [dx, 0, 1]: pere
+              [dx, 1, 0]: erola
+              [dx, 1, 1]: marta
+              [dx, 2, 0]: victor
+              [dx, 2, 1]: jordi
+              [dx, 3, 0]: eduard
+              [dx, 3, 1]: victor
+
+              [dj, 0, 0]: judith
+              [dj, 0, 1]: carles
+              [dj, 1, 0]: silvia
+              [dj, 1, 1]: judith
+              [dj, 2, 0]: monica
+              [dj, 2, 1]: judit
+              [dj, 3, 0]: judit
+              [dj, 3, 1]: joan
+
+              [dv, 0, 0]: ana
+              [dv, 0, 1]: judith
+              [dv, 1, 0]: jordi
+              [dv, 1, 1]: ana
+              [dv, 2, 0]: victor
+              [dv, 2, 1]: carles
+              [dv, 3, 0]: marta
+              [dv, 3, 1]: silvia
+        """)
+
+
 
 
 unittest.TestCase.__str__ = unittest.TestCase.id

--- a/tomatic/scheduling_test.py
+++ b/tomatic/scheduling_test.py
@@ -949,198 +949,120 @@ class Scheduling_Test(unittest.TestCase):
                   victor: Víctor
             """)
 
+    def baseCase(self):
+        return ns.loads("""\
+            dl:
+            - - jordi
+              - tania
+            - - tania
+              - silvia
+            - - judith
+              - ana
+            - - ana
+              - erola
+            dm:
+            - - pere
+              - victor
+            - - carles
+              - ana
+            - - joan
+              - eduard
+            - - david
+              - monica
+            dx:
+            - - yaiza
+              - pere
+            - - erola
+              - marta
+            - - victor
+              - jordi
+            - - eduard
+              - victor
+            dj:
+            - - judith
+              - carles
+            - - silvia
+              - judith
+            - - monica
+              - judit
+            - - judit
+              - joan
+            dv:
+            - - ana
+              - judith
+            - - jordi
+              - ana
+            - - victor
+              - carles
+            - - marta
+              - silvia
+        """)
+
+    def baseCaseOutput(self):
+        return ns.loads("""\
+            [dl, 0, 0]: jordi
+            [dl, 0, 1]: tania
+            [dl, 1, 0]: tania
+            [dl, 1, 1]: silvia
+            [dl, 2, 0]: judith
+            [dl, 2, 1]: ana
+            [dl, 3, 0]: ana
+            [dl, 3, 1]: erola
+
+            [dm, 0, 0]: pere
+            [dm, 0, 1]: victor
+            [dm, 1, 0]: carles
+            [dm, 1, 1]: ana
+            [dm, 2, 0]: joan
+            [dm, 2, 1]: eduard
+            [dm, 3, 0]: david
+            [dm, 3, 1]: monica
+
+            [dx, 0, 0]: yaiza
+            [dx, 0, 1]: pere
+            [dx, 1, 0]: erola
+            [dx, 1, 1]: marta
+            [dx, 2, 0]: victor
+            [dx, 2, 1]: jordi
+            [dx, 3, 0]: eduard
+            [dx, 3, 1]: victor
+
+            [dj, 0, 0]: judith
+            [dj, 0, 1]: carles
+            [dj, 1, 0]: silvia
+            [dj, 1, 1]: judith
+            [dj, 2, 0]: monica
+            [dj, 2, 1]: judit
+            [dj, 3, 0]: judit
+            [dj, 3, 1]: joan
+
+            [dv, 0, 0]: ana
+            [dv, 0, 1]: judith
+            [dv, 1, 0]: jordi
+            [dv, 1, 1]: ana
+            [dv, 2, 0]: victor
+            [dv, 2, 1]: carles
+            [dv, 3, 0]: marta
+            [dv, 3, 1]: silvia
+      """)
+
     def test_timetable2forcedTurns_baseCase(self):
-        timetable = ns.loads("""\
-              dl:
-              - - jordi
-                - tania
-              - - tania
-                - silvia
-              - - judith
-                - ana
-              - - ana
-                - erola
-              dm:
-              - - pere
-                - victor
-              - - carles
-                - ana
-              - - joan
-                - eduard
-              - - david
-                - monica
-              dx:
-              - - yaiza
-                - pere
-              - - erola
-                - marta
-              - - victor
-                - jordi
-              - - eduard
-                - victor
-              dj:
-              - - judith
-                - carles
-              - - silvia
-                - judith
-              - - monica
-                - judit
-              - - judit
-                - joan
-              dv:
-              - - ana
-                - judith
-              - - jordi
-                - ana
-              - - victor
-                - carles
-              - - marta
-                - silvia
-        """)
+        timetable = self.baseCase()
+
         forced = timetable2forced(timetable)
-        self.assertNsEqual(forced, """\
-              [dl, 0, 0]: jordi
-              [dl, 0, 1]: tania
-              [dl, 1, 0]: tania
-              [dl, 1, 1]: silvia
-              [dl, 2, 0]: judith
-              [dl, 2, 1]: ana
-              [dl, 3, 0]: ana
-              [dl, 3, 1]: erola
 
-              [dm, 0, 0]: pere
-              [dm, 0, 1]: victor
-              [dm, 1, 0]: carles
-              [dm, 1, 1]: ana
-              [dm, 2, 0]: joan
-              [dm, 2, 1]: eduard
-              [dm, 3, 0]: david
-              [dm, 3, 1]: monica
-
-              [dx, 0, 0]: yaiza
-              [dx, 0, 1]: pere
-              [dx, 1, 0]: erola
-              [dx, 1, 1]: marta
-              [dx, 2, 0]: victor
-              [dx, 2, 1]: jordi
-              [dx, 3, 0]: eduard
-              [dx, 3, 1]: victor
-
-              [dj, 0, 0]: judith
-              [dj, 0, 1]: carles
-              [dj, 1, 0]: silvia
-              [dj, 1, 1]: judith
-              [dj, 2, 0]: monica
-              [dj, 2, 1]: judit
-              [dj, 3, 0]: judit
-              [dj, 3, 1]: joan
-
-              [dv, 0, 0]: ana
-              [dv, 0, 1]: judith
-              [dv, 1, 0]: jordi
-              [dv, 1, 1]: ana
-              [dv, 2, 0]: victor
-              [dv, 2, 1]: carles
-              [dv, 3, 0]: marta
-              [dv, 3, 1]: silvia
-        """)
-
+        self.assertNsEqual(forced, self.baseCaseOutput())
 
     def test_timetable2forcedTurns_unfilledSlots(self):
-        timetable = ns.loads("""\
-              dl:
-              - - jordi
-                - tania
-              - - tania
-                - silvia
-              - - null   # This is different from basecase
-                - ana
-              - - ana
-                - erola
-              dm:
-              - - pere
-                - victor
-              - - carles
-                - ana
-              - - joan
-                - eduard
-              - - david
-                - monica
-              dx:
-              - - yaiza
-                - pere
-              - - erola
-                - marta
-              - - victor
-                - jordi
-              - - eduard
-                - victor
-              dj:
-              - - judith
-                - carles
-              - - silvia
-                - judith
-              - - monica
-                - judit
-              - - judit
-                - joan
-              dv:
-              - - ana
-                - judith
-              - - jordi
-                - ana
-              - - victor
-                - carles
-              - - marta
-                - silvia
-        """)
+        timetable = self.baseCase()
+        timetable['dl'][2][0] = None
+
         forced = timetable2forced(timetable)
-        self.assertNsEqual(forced, """\
-              [dl, 0, 0]: jordi
-              [dl, 0, 1]: tania
-              [dl, 1, 0]: tania
-              [dl, 1, 1]: silvia
-              # [dl, 2, 0]: judith  # This should be skipped
-              [dl, 2, 1]: ana
-              [dl, 3, 0]: ana
-              [dl, 3, 1]: erola
 
-              [dm, 0, 0]: pere
-              [dm, 0, 1]: victor
-              [dm, 1, 0]: carles
-              [dm, 1, 1]: ana
-              [dm, 2, 0]: joan
-              [dm, 2, 1]: eduard
-              [dm, 3, 0]: david
-              [dm, 3, 1]: monica
+        expected = self.baseCaseOutput()
+        del expected['dl',2,0]
+        self.assertNsEqual(forced, expected)
 
-              [dx, 0, 0]: yaiza
-              [dx, 0, 1]: pere
-              [dx, 1, 0]: erola
-              [dx, 1, 1]: marta
-              [dx, 2, 0]: victor
-              [dx, 2, 1]: jordi
-              [dx, 3, 0]: eduard
-              [dx, 3, 1]: victor
-
-              [dj, 0, 0]: judith
-              [dj, 0, 1]: carles
-              [dj, 1, 0]: silvia
-              [dj, 1, 1]: judith
-              [dj, 2, 0]: monica
-              [dj, 2, 1]: judit
-              [dj, 3, 0]: judit
-              [dj, 3, 1]: joan
-
-              [dv, 0, 0]: ana
-              [dv, 0, 1]: judith
-              [dv, 1, 0]: jordi
-              [dv, 1, 1]: ana
-              [dv, 2, 0]: victor
-              [dv, 2, 1]: carles
-              [dv, 3, 0]: marta
-              [dv, 3, 1]: silvia
-        """)
 
 
 unittest.TestCase.__str__ = unittest.TestCase.id

--- a/tomatic/scheduling_test.py
+++ b/tomatic/scheduling_test.py
@@ -1046,6 +1046,101 @@ class Scheduling_Test(unittest.TestCase):
         """)
 
 
+    def test_timetable2forcedTurns_unfilledSlots(self):
+        timetable = ns.loads("""\
+              dl:
+              - - jordi
+                - tania
+              - - tania
+                - silvia
+              - - null   # This is different from basecase
+                - ana
+              - - ana
+                - erola
+              dm:
+              - - pere
+                - victor
+              - - carles
+                - ana
+              - - joan
+                - eduard
+              - - david
+                - monica
+              dx:
+              - - yaiza
+                - pere
+              - - erola
+                - marta
+              - - victor
+                - jordi
+              - - eduard
+                - victor
+              dj:
+              - - judith
+                - carles
+              - - silvia
+                - judith
+              - - monica
+                - judit
+              - - judit
+                - joan
+              dv:
+              - - ana
+                - judith
+              - - jordi
+                - ana
+              - - victor
+                - carles
+              - - marta
+                - silvia
+        """)
+        forced = timetable2forced(timetable)
+        self.assertNsEqual(forced, """\
+              [dl, 0, 0]: jordi
+              [dl, 0, 1]: tania
+              [dl, 1, 0]: tania
+              [dl, 1, 1]: silvia
+              # [dl, 2, 0]: judith  # This should be skipped
+              [dl, 2, 1]: ana
+              [dl, 3, 0]: ana
+              [dl, 3, 1]: erola
+
+              [dm, 0, 0]: pere
+              [dm, 0, 1]: victor
+              [dm, 1, 0]: carles
+              [dm, 1, 1]: ana
+              [dm, 2, 0]: joan
+              [dm, 2, 1]: eduard
+              [dm, 3, 0]: david
+              [dm, 3, 1]: monica
+
+              [dx, 0, 0]: yaiza
+              [dx, 0, 1]: pere
+              [dx, 1, 0]: erola
+              [dx, 1, 1]: marta
+              [dx, 2, 0]: victor
+              [dx, 2, 1]: jordi
+              [dx, 3, 0]: eduard
+              [dx, 3, 1]: victor
+
+              [dj, 0, 0]: judith
+              [dj, 0, 1]: carles
+              [dj, 1, 0]: silvia
+              [dj, 1, 1]: judith
+              [dj, 2, 0]: monica
+              [dj, 2, 1]: judit
+              [dj, 3, 0]: judit
+              [dj, 3, 1]: joan
+
+              [dv, 0, 0]: ana
+              [dv, 0, 1]: judith
+              [dv, 1, 0]: jordi
+              [dv, 1, 1]: ana
+              [dv, 2, 0]: victor
+              [dv, 2, 1]: carles
+              [dv, 3, 0]: marta
+              [dv, 3, 1]: silvia
+        """)
 
 
 unittest.TestCase.__str__ = unittest.TestCase.id


### PR DESCRIPTION
## Description

Provides a way of fixing turns in 

## Changes

- Besides hardcoded fixed turns in `config.yaml:forced` (containing a mapping (day, hour, line)->person), now a new parameter  `config.yaml:forcedTimeTable` can be confgured to specify a timetable yaml file that could be edited using tomatic timetable editor.
- Make minizinc based timetable (graella) scheduler also enforce fixed turns
- Adapt to new parameter naming in tomato-cooker (the minizinc solver)
- Minizinc scheduler ignores fixed turns in holidays or unavailabilities
- Minizinc scheduler just enforces fixed turns up to the person maximum load.
- `deterministic` param for minizinc in order to b2b
- TODO: How Scheduler processes ningu's in load
- TODO: Different editing for ningus (fixed hole) and null (to be filled hole)

## Observations

- Editing the timetable with 'ningu' still set a forced ningu. Edit by hand and set the slot to `null`.
- The planner launcher, links to the one in data/forced-turns.yaml if that file exists
- If the parameter or the file does not  exist then tries the old `forced` parameter in config.yaml as previously which is a mapping of (day, hour, line) -> person and empty by default.
- In production and in pebrotic, we will link that file to a timetable with date in the far future

## Please, review

- Wheter it works locally or in pebrotic

## How to check the new features

- In local:
    - From the planer, generate a grid with few lines and upload it
    - Edit it setting all slot to null but the ones we want fixed
    - Copy or link it to data/fixed-turns.yaml
    - Set 

## Deploy notes

- forcedTimeTable parameter added to 


