### PR TITLE
🐛 Fix validation name in SetPersonData of api/person

### DIFF
--- a/tomatic/ui/src/services/tomatic.js
+++ b/tomatic/ui/src/services/tomatic.js
@@ -408,11 +408,7 @@ module.exports = (function () {
       var value = data[key]
       switch (key) {
         case 'formatName':
-          delete Tomatic.persons().names[name]
-          var formatName = Tomatic.formatName(name)
-          if (formatName !== value) {
-            postdata.name = value
-          }
+          postdata.name = value
           break
         case 'extension':
           postdata.extension = value


### PR DESCRIPTION
 Co-authored-by: Marta <marta.fernandez@somenergia.coop>

## Description

When the choosen _nom_ was the same that the _identificador_ but with capital letter, the new name was not saved. It was due to the `formatName !== value` validation. 

## Changes

- Comprehensive list of changes (effect, not process)

## Observations

## Please, review

- List of things authors emphasize to review

## How to check the new features

## Deploy notes


