### PR TITLE
Menu and dialog to emulate incoming call

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Fix: Nicer handling of api calls when not authenticated
 - Fix: Button for adding lines not always works
 - New Makefile targets for styling and b2b tests
+- A menu option to emulate an incoming call for testing purposes
 
 ## 5.5.3 2024-03-12
 

--- a/tomatic/ui/src/components/EmulateCallDialog.js
+++ b/tomatic/ui/src/components/EmulateCallDialog.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import DialogTitle from '@mui/material/DialogTitle'
+import DialogContent from '@mui/material/DialogContent'
+import DialogActions from '@mui/material/DialogActions'
+import Button from '@mui/material/Button'
+import TextField from '@mui/material/TextField'
+import Stack from '@mui/material/Stack'
+import AuthContext from '../contexts/AuthContext'
+import Tomatic from '../services/tomatic'
+import CallInfo from '../mithril/components/callinfo'
+
+export default function EmulateCallDialog({ closeDialog }) {
+  const {userid} = React.useContext(AuthContext)
+  const [extension, setExtension] = React.useState(()=>Tomatic.persons().extensions[userid])
+  const [phoneNumber, setPhoneNumber] = React.useState('')
+
+  const isValid = /^\d{3}$/.test(extension) && /^\d{9}$/.test(phoneNumber)
+  function submit() {
+    CallInfo.emulateCall(phoneNumber, extension)
+    closeDialog()
+  }
+  return (
+    <>
+      <DialogTitle>{'Emula trucada entrant'}</DialogTitle>
+      <DialogContent>
+        <Stack gap={2}>
+          <TextField
+            disabled
+            value={extension}
+            onChange={(e) => setExtension(e.target.value)}
+            label={'Extensió'}
+            variant="standard"
+            fullWidth
+            rows={4}
+          />
+          <TextField
+            value={phoneNumber}
+            onChange={(e) => setPhoneNumber(e.target.value)}
+            pattern="^\d{9}$"
+            label={'Número de telèfon'}
+            variant="standard"
+            fullWidth
+            rows={4}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={closeDialog}>{'Cancel·la'}</Button>
+        <Button variant="contained" disabled={!isValid} onClick={submit}>
+          {'Simula trucada'}
+        </Button>
+      </DialogActions>
+    </>
+  )
+}

--- a/tomatic/ui/src/components/ProfileButton.js
+++ b/tomatic/ui/src/components/ProfileButton.js
@@ -26,8 +26,10 @@ import editAvailabilities from '../mithril/components/busyeditor'
 import editPerson from '../mithril/components/editperson'
 import { useDialog } from './DialogProvider'
 import { CopyCalendarDialog } from './CopyCalendarDialog'
+import EmulateCallDialog from './EmulateCallDialog'
 
 var openCalendarDialog = () => {}
+var openCallEmulationDialog = () => {}
 
 const menuProfile = [
   {
@@ -55,6 +57,13 @@ const menuProfile = [
     text: 'Kumato mode',
     icon: <IconKumato />,
     onclick: Tomatic.toggleKumato,
+  },
+  {
+    text: 'Emula trucada entrant',
+    icon: '🤙',
+    onclick: () => {
+      openCallEmulationDialog()
+    },
   },
   {
     text: 'Logout',
@@ -85,6 +94,12 @@ function ProfileButton() {
     },
     [openDialog, closeDialog],
   )
+
+  openCallEmulationDialog = React.useCallback(() => {
+    openDialog({
+      children: <EmulateCallDialog {...{ closeDialog }} />,
+    })
+  }, [openDialog, closeDialog])
 
   return (
     <Box sx={{ flexGrow: 0 }}>

--- a/tomatic/ui/src/mithril/components/callinfo.js
+++ b/tomatic/ui/src/mithril/components/callinfo.js
@@ -492,6 +492,20 @@ CallInfo.onMessageReceived = function (event) {
   }
   console.debug('Message received from WebSockets and type not recognized.')
 }
+CallInfo.emulateCall = function (phone, extension) {
+  api
+    .request({
+      url: '/api/info/ringring',
+      params: {
+        extension: extension,
+        phone: phone,
+      },
+    })
+    .then(function (response) {
+      console.log(`Call emulated from ${phone} to ${extension}`)
+    })
+}
+
 CallInfo.getCategories()
 CallInfo.getLogPerson()
 


### PR DESCRIPTION
## Description

Testing feature to emulate incoming calls.

In order to test callinfo, either in pebrotic or in a development setup, you don't have a call log from the pbx. In pebrotic, you could call the test phone number, but usually is more practical to emulate a pbx calls calling the api. Using curl could be a no brainer for developers but it is unpractical for testers.

This PR adds a menu entry that opens a dialog which calls the entry point for pbxs to emulate an incoming call.
<img width="25%" src="https://github.com/Som-Energia/somenergia-tomatic/assets/532178/35a87159-9ffb-4be5-833f-cbad4f6e0ad3" alt="tomatic-emulatrucada-menu" />
<img width="25%" src="https://github.com/Som-Energia/somenergia-tomatic/assets/532178/3e7dc969-4a3a-4ca2-bd66-91d5ea152141" alt="tomatic-emulatrucada-dialeg" />
<img width="25%" src="https://github.com/Som-Energia/somenergia-tomatic/assets/532178/381d666e-d12d-49e6-856d-b8cb17b8017a" alt="tomatic-emulatrucada-result" />

## Changes

A menu entry and the dialog.

## Observations

- In profile menu, even though the extra comands menu would be more suitable. That's because the extra menu is still mithril and the new dialog is React. We could moved it when we migrate extras menu.
- This menu should be available only when in development/testing modes. The problem is that we still have no set those environments in a proper way.

## Please, review

- That the list of calls is updated after sending the emulated call.

## How to check the new features

- A setup is done in pebrotic for convenience

## Deploy notes


