### PR TITLE
✨ get festivities from odoo

### DIFF
--- a/tomatic/retriever.py
+++ b/tomatic/retriever.py
@@ -80,21 +80,20 @@ def downloadFestivities(config):
         workweek=4, # This is what is needed just for schedulings
         year=366, # This is useful for many other uses, not yet slower
     )
-
     import erppeek
-    from yamlns.dateutils import Date
     erp = erppeek.Client(**secrets('tomatic.holidaysodoo'))
     firstDay = addDays(config.monday, 0)
     lastDay = addDays(config.monday, intervals['year'])
-    Festivities = erp.model('hr.holidays.public.line')
-    festivity_ids = Festivities.search([
-        ('date', '>=', str(firstDay)),
-        ('date', '<=', str(lastDay)),
-    ])
+    festivities = erp.model('hr.holidays.public.line').get_festivities(
+        firstDay.strftime("%Y-%m-%d"), lastDay.strftime("%Y-%m-%d")
+    )
     holidaysfile = Path('holidays.conf')
     with holidaysfile.open('w', encoding='utf8') as output:
-        for festivity in Festivities.read(festivity_ids, ['date','meeting_id']) or []:
-            output.write('{date}\t{meeting_id[1]}\n'.format(**festivity))
+        for festivity in festivities:
+            output.write('{date}\t{name}\n'.format(
+                date=festivity['date'],
+                name=festivity['name']
+            ))
         no_service_file = Path('data')/'noservice.conf'
         if no_service_file.exists():
             no_service_days = no_service_file.read_text()


### PR DESCRIPTION
## Description

A new function called `get_festivities` was created in Odoo, so we use it now.

## Changes

- Use of `get_festivities`.

## Checklist

Justify any unchecked point:

- [ ] Changed code is covered by tests: there were no tests...
- [ ] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file: doing it in the bump commit
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups: **N/A**
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation: **N/A**

## Observations

The new function returns a 'date' and a 'name'. It may not be a problem, but there is a little difference in the final file. Before the changes, the information was presented like "Divendres Sant (Espanya)" (`meeting_id`) and now it's like "Divendres Sant" (`name`). *In practical terms*, I guess there is no difference, because in `tomatic/minizinc_test.py` we can see that the new format matches the test format. But I'll keep looking at this, to ensure it's ok.
